### PR TITLE
Fix integer division in calcIntensityTrace

### DIFF
--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/Imaging_FCS.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/Imaging_FCS.java
@@ -13066,8 +13066,8 @@ public class Imaging_FCS implements PlugIn {
         // initialframe and finalframe provide the range of frames to be used
         // isDCsubtract: whether to perform constant value subtraction
         int ave = (int) Math.floor((finalframe - initialframe + 1) / nopit); // calculate number of data points which are averaged
-        int sum1;
-        int sum2;
+        double sum1;
+        double sum2;
         int bckg1 = background;
         int bckg2 = background;	//needs to be adapted for background2 once available
 
@@ -13110,8 +13110,8 @@ public class Imaging_FCS implements PlugIn {
         // imageType: 1 - accept raw imp (16-bit); 2 - accept bleach corrected imp (32-bit). 32-bit bleach corrected image follows the same shape as output parameter maps
 
         int ave = (int) Math.floor((finalframe - initialframe + 1) / nopit); // calculate number of data points which are averaged
-        int sum1;
-        int sum2;
+        double sum1;
+        double sum2;
         int bckg1 = background;
         int bckg2 = background;	//needs to be adapted for background2 once available
         int imageType;


### PR DESCRIPTION
Integer division during averaging means that the intensity trace used for bleach correction is not correct.

This fix is summarized below:
![image](https://github.com/Biophysical-Fluorescence-Laboratory/Imaging_FCS/assets/67615798/92bdd16a-4531-42cc-848a-cffa5457c5e2)
