### PR TITLE
Reset all results when settings are changed

### DIFF
--- a/src/main/java/fiji/plugin/imaging_fcs/new_imfcs/model/correlations/Correlator.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/new_imfcs/model/correlations/Correlator.java
@@ -956,6 +956,10 @@ public class Correlator {
      */
     public void resetResults() {
         pixelModels = null;
+        lags = null;
+        lagTimes = null;
+        sampleTimes = null;
+        numSamples = null;
     }
 
     public Map<String, double[][]> getDccf() {


### PR DESCRIPTION
Fix #25

This fixes the issue where you put a higher correlator p or q value after doing a first experiment.