### PR TITLE
Add onnx features

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,12 @@
             <artifactId>snakeyaml</artifactId>
             <version>2.2</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.microsoft.onnxruntime</groupId>
+            <artifactId>onnxruntime_gpu</artifactId>
+            <version>1.21.0</version>
+        </dependency>
     </dependencies>
 
     <!-- This part is used to create the header file and/or compile the C++/CUDA libraries if needed -->

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,3 @@
+mvn clean package
+java -jar target/ImagingFCS-2_0.jar
+

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/controller/MainPanelController.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/controller/MainPanelController.java
@@ -12,6 +12,7 @@ import fiji.plugin.imaging_fcs.imfcs.model.correlations.MeanSquareDisplacement;
 import fiji.plugin.imaging_fcs.imfcs.utils.*;
 import fiji.plugin.imaging_fcs.imfcs.view.BleachCorrectionView;
 import fiji.plugin.imaging_fcs.imfcs.view.ExpSettingsView;
+import fiji.plugin.imaging_fcs.imfcs.view.OnnxInferenceView;
 import fiji.plugin.imaging_fcs.imfcs.view.MainPanelView;
 import fiji.plugin.imaging_fcs.imfcs.view.Plots;
 import fiji.plugin.imaging_fcs.imfcs.view.dialogs.*;
@@ -64,6 +65,7 @@ public final class MainPanelController {
     private final FilteringController filteringController;
     private final ParameterVideoController parameterVideoController;
     private final Correlator correlator;
+    private final OnnxInferenceView onnxInferenceView;
 
     /**
      * Constructor that initializes models, views, and other controllers needed for the main panel.
@@ -136,6 +138,7 @@ public final class MainPanelController {
         this.expSettingsView = new ExpSettingsView(this, settings);
         updateSettingsField();
         this.view = new MainPanelView(this, this.settings);
+        this.onnxInferenceView = new OnnxInferenceView();
 
         if (workbook != null) {
             // read the Excel file to restore parameters
@@ -1208,5 +1211,16 @@ public final class MainPanelController {
             setter.accept(value);
             fitController.updateFitEnd(settings);
         };
+    }
+
+    // ONNX-related controller options.
+    /**
+     * Returns an item listener to handle the "ONNX Models" toggle button press event.
+     * This listener toggles the visibility of the ONNX Models view.
+     *
+     * @return an ItemListener that processes the "ONNX Models Infernece" toggle button press event
+     */
+    public ItemListener tbOnnxInferencePressed() {
+        return (ItemEvent ev) -> onnxInferenceView.setVisible(ev.getStateChange() == ItemEvent.SELECTED);
     }
 }

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/controller/MainPanelController.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/controller/MainPanelController.java
@@ -12,7 +12,6 @@ import fiji.plugin.imaging_fcs.imfcs.model.correlations.MeanSquareDisplacement;
 import fiji.plugin.imaging_fcs.imfcs.utils.*;
 import fiji.plugin.imaging_fcs.imfcs.view.BleachCorrectionView;
 import fiji.plugin.imaging_fcs.imfcs.view.ExpSettingsView;
-import fiji.plugin.imaging_fcs.imfcs.view.OnnxInferenceView;
 import fiji.plugin.imaging_fcs.imfcs.view.MainPanelView;
 import fiji.plugin.imaging_fcs.imfcs.view.Plots;
 import fiji.plugin.imaging_fcs.imfcs.view.dialogs.*;

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/controller/MainPanelController.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/controller/MainPanelController.java
@@ -140,7 +140,7 @@ public final class MainPanelController {
         this.view = new MainPanelView(this, this.settings);
 
         // ONNX Inference-specific views.
-        this.onnxInferenceModel = new OnnxInferenceModel(bleachCorrectionModel);
+        this.onnxInferenceModel = new OnnxInferenceModel(bleachCorrectionModel, optionsModel.isCuda());
         this.onnxInferenceController = new OnnxInferenceController(this.onnxInferenceModel);
 
         if (workbook != null) {

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/controller/MainPanelController.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/controller/MainPanelController.java
@@ -141,7 +141,7 @@ public final class MainPanelController {
 
         // ONNX Inference-specific views.
         this.onnxInferenceModel = new OnnxInferenceModel(bleachCorrectionModel, optionsModel.isCuda());
-        this.onnxInferenceController = new OnnxInferenceController(this.onnxInferenceModel);
+        this.onnxInferenceController = new OnnxInferenceController(this.onnxInferenceModel, imageModel, settings);
 
         if (workbook != null) {
             // read the Excel file to restore parameters

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/controller/MainPanelController.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/controller/MainPanelController.java
@@ -65,7 +65,8 @@ public final class MainPanelController {
     private final FilteringController filteringController;
     private final ParameterVideoController parameterVideoController;
     private final Correlator correlator;
-    private final OnnxInferenceView onnxInferenceView;
+    private final OnnxInferenceModel onnxInferenceModel;
+    private final OnnxInferenceController onnxInferenceController;
 
     /**
      * Constructor that initializes models, views, and other controllers needed for the main panel.
@@ -138,7 +139,10 @@ public final class MainPanelController {
         this.expSettingsView = new ExpSettingsView(this, settings);
         updateSettingsField();
         this.view = new MainPanelView(this, this.settings);
-        this.onnxInferenceView = new OnnxInferenceView();
+
+        // ONNX Inference-specific views.
+        this.onnxInferenceModel = new OnnxInferenceModel(bleachCorrectionModel);
+        this.onnxInferenceController = new OnnxInferenceController(this.onnxInferenceModel);
 
         if (workbook != null) {
             // read the Excel file to restore parameters
@@ -1221,6 +1225,9 @@ public final class MainPanelController {
      * @return an ItemListener that processes the "ONNX Models Infernece" toggle button press event
      */
     public ItemListener tbOnnxInferencePressed() {
-        return (ItemEvent ev) -> onnxInferenceView.setVisible(ev.getStateChange() == ItemEvent.SELECTED);
+        return (ItemEvent ev) -> {
+            boolean selected = (ev.getStateChange() == ItemEvent.SELECTED);
+            onnxInferenceController.setVisible(selected);
+        };
     }
 }

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/controller/OnnxBatchController.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/controller/OnnxBatchController.java
@@ -1,0 +1,118 @@
+package fiji.plugin.imaging_fcs.imfcs.controller;
+
+import fiji.plugin.imaging_fcs.imfcs.model.onnx.OnnxBatchModel;
+import fiji.plugin.imaging_fcs.imfcs.view.OnnxBatchView;
+import ij.IJ;
+
+import java.awt.event.ItemListener;
+
+/**
+ * Controller for the OnnxBatchView. Manages user input related to batch sizing
+ * and prefetching, updating the OnnxBatchModel.
+ */
+public class OnnxBatchController {
+    private final OnnxBatchModel model;
+    private final OnnxBatchView view;
+
+    // Assuming the setBatchSize/setNumPrefetchWorkers methods in the model 
+    // now take Integer/int as arguments to match the View's getters:
+    // NOTE: If the model uses String setters (as in your last provided model), 
+    // the update methods below are obsolete, and only initialization is needed.
+
+    public OnnxBatchController(OnnxBatchModel model) {
+        this.model = model;
+        this.view = new OnnxBatchView(this, model); 
+        
+        // Initialize the view with current model state
+        this.updateViewFromModel();
+        
+        // Add listeners ONLY for components not using direct FocusListeners (i.e., the Checkbox)
+        this.initializeListeners();
+    }
+
+    /**
+     * Initializes listeners for the Batch View components.
+     */
+    private void initializeListeners() {
+        // Listener for the Enable Batching CheckBox (ItemEvent)
+        this.view.setBatchEnabledListener(this.createBatchEnabledListener());
+        
+        // REMOVED: Listener for Batch Size (Handled by FocusListener in View)
+        // REMOVED: Listener for Prefetch Workers (Handled by FocusListener in View)
+    }
+
+    /**
+     * Creates an ItemListener for the enable batching checkbox.
+     */
+    private ItemListener createBatchEnabledListener() {
+        return e -> {
+            boolean enabled = this.view.getBatchEnabledStatus();
+            
+            // 1. Update the Model based on the toggle state.
+            this.model.setBatchingEnabled(enabled);
+            
+            // 2. Perform necessary UI and status updates.
+            this.updateModelAndViewAfterToggle(enabled);
+            IJ.log("ONNX Batching enabled: " + enabled);
+            
+            // Note: Since setBatchingEnabled in the model resets values if disabled, 
+            // the updateViewFromModel call inside updateModelAndViewAfterToggle 
+            // will automatically sync the text fields if the user disables batching.
+        };
+    }
+
+    // Since text fields use FocusListeners writing directly to the Model 
+    // (model::setBatchSize and model::setNumPrefetchWorkers), 
+    // we should remove the manual update methods from the controller.
+    /*
+    private void updateBatchSize() { ... } // REMOVED
+    private void updatePrefetchWorkers() { ... } // REMOVED
+    */
+
+    /**
+     * Ensures the view reflects the model's state (used for initialization and
+     * resetting defaults).
+     */
+    private void updateViewFromModel() {
+        // Set text fields based on model values
+        this.view.setBatchSizeText(String.valueOf(this.model.getBatchSize()));
+        this.view.setPrefetchWorkersText(String.valueOf(this.model.getNumPrefetchWorkers()));
+
+        // Set checkbox status
+        this.view.setBatchEnabledStatus(this.model.isBatchingEnabled());
+        
+        // Set input fields enabled/disabled state
+        this.view.setInputsEnabled(this.model.isBatchingEnabled());
+
+        // Update status label on initialization
+        String status = this.model.isBatchingEnabled() ? "Batching enabled." : "Status: Disabled";
+        this.view.updateStatus(status);
+    }
+    
+    /**
+     * Updates the model's state in the view after the batch toggle is pressed.
+     * 
+     * @param enabled The new state of batching.
+     */
+    private void updateModelAndViewAfterToggle(boolean enabled) {
+        // When batching is disabled, the model resets batchSize and workers to defaults.
+        if (!enabled) {
+            // Revert the view text fields to reflect the model's reset defaults (1 and 0)
+            this.updateViewFromModel(); 
+            this.view.updateStatus("Batching disabled. Default settings applied.");
+        } else {
+            this.view.updateStatus("Batching enabled.");
+        }
+        
+        // Enable/Disable the text fields
+        this.view.setInputsEnabled(enabled); 
+    }
+
+    public OnnxBatchView getView() {
+        return view;
+    }
+
+    public OnnxBatchModel getModel() {
+        return model;
+    }
+}

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/controller/OnnxInferenceController.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/controller/OnnxInferenceController.java
@@ -195,9 +195,11 @@ public class OnnxInferenceController {
     }
 
     public void teardownOnnxSession() {
-        this.model.closeOnnxSession();
-        this.view.updateStatus(this.model.getCurrentStatus().getDisplayLabel());
-        this.view.disableRunInferenceButton();
+        if (this.model != null) {
+            this.model.closeOnnxSession();
+            this.view.updateStatus(this.model.getCurrentStatus().getDisplayLabel());
+            this.view.disableRunInferenceButton();
+        }
     }
 
     /**

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/controller/OnnxInferenceController.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/controller/OnnxInferenceController.java
@@ -48,6 +48,7 @@ public class OnnxInferenceController {
 
             // Print the file path
             System.out.println("Selected ONNX model file: " + filePath);
+            this.view.updateModelPath(filePath);
         }
     }
     

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/controller/OnnxInferenceController.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/controller/OnnxInferenceController.java
@@ -226,4 +226,8 @@ public class OnnxInferenceController {
         Map<String, ImagePlus> outputMaps = this.infer();
 
     }
+
+	public void startOnnxSession() {
+        this.model.startOnnxSession();
+	}
 }

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/controller/OnnxInferenceController.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/controller/OnnxInferenceController.java
@@ -364,4 +364,47 @@ public class OnnxInferenceController {
     public void startOnnxSession() {
         this.model.startOnnxSession();
     }
+
+    public boolean canDoInference() {
+        return this.model.canFit();
+    }
+
+    // Function for saving during the Batch mode inference.
+    // Designed to interface well with the existing Batch processing.
+    // NOTE: The reason this is separate is because the existing batch processing is
+    // a bit constrained.
+    // i.e. windows are only ever saved as PNG files, and only saved when "Save
+    // Plots" is toggled.
+    // This function guarantees that ONNX inference outputs are saved.
+    public static void saveOnnxOutputMaps(Map<String, ImagePlus> outputMaps, String path) {
+        for (Map.Entry<String, ImagePlus> entry : outputMaps.entrySet()) {
+            String title = entry.getKey();
+            ImagePlus imp = entry.getValue(); // The new image data
+
+            if (imp == null) {
+                System.out.println("Skipping null ImagePlus associated with key: " + title);
+                continue; // Skip to the next entry
+            }
+
+            // Set the title on the new ImagePlus regardless, needed for comparison/display
+            imp.setTitle(title);
+
+            // Remove the last part with parentheses, if present
+            title = title.replaceAll("\\s*\\([^)]*\\)", "");
+
+            // Trim any trailing whitespace after removing parentheses
+            title = title.trim();
+
+            // Replace spaces with underscores
+            title = title.replace(" ", "_");
+
+            // Replace slashes with "up" (this prevents error since / is used to separate
+            // folders)
+            title = title.replace("/", "up");
+            // Same here since \ is used for Windows
+            title = title.replace("\\", "down");
+
+            IJ.saveAsTiff(imp, path + "_onnx" + title + ".tiff");
+        }
+    }
 }

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/controller/OnnxInferenceController.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/controller/OnnxInferenceController.java
@@ -1,8 +1,17 @@
 
 package fiji.plugin.imaging_fcs.imfcs.controller;
 
+import java.io.File;
+
+import javax.swing.JFileChooser;
+import javax.swing.filechooser.FileNameExtensionFilter;
+
+import ai.onnxruntime.OrtException;
+import fiji.plugin.imaging_fcs.imfcs.model.ExpSettingsModel;
+import fiji.plugin.imaging_fcs.imfcs.model.ImageModel;
 import fiji.plugin.imaging_fcs.imfcs.model.OnnxInferenceModel;
 import fiji.plugin.imaging_fcs.imfcs.view.OnnxInferenceView;
+import ij.IJ;
 
 /**
  * The OnnxInferenceController class handles the interactions between the OnnxInferneceModel and the OnnxInferenceView,
@@ -19,7 +28,45 @@ public class OnnxInferenceController {
      */
     public OnnxInferenceController(OnnxInferenceModel model) {
         this.model = model;
-        this.view = new OnnxInferenceView(model);
+        this.view = new OnnxInferenceView(this, model);
+    }
+    
+    // Load an ONNX Model.
+    public void btnLoadPressed() {
+        JFileChooser fileChooser = new JFileChooser();
+        fileChooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
+        FileNameExtensionFilter filter = new FileNameExtensionFilter("ONNX Protobuf Models", "onnx");
+        fileChooser.setFileFilter(filter);
+
+        int returnVal = fileChooser.showOpenDialog(null);
+        if (returnVal == JFileChooser.APPROVE_OPTION) {
+             // Get the selected file object
+            File selectedFile = fileChooser.getSelectedFile();
+
+            // Get the absolute path of the selected file as a String
+            String filePath = selectedFile.getAbsolutePath();
+
+            // Print the file path
+            System.out.println("Selected ONNX model file: " + filePath);
+        }
+    }
+    
+    // TODO: This should return an ImagePlus (?)
+    public void infer(ImageModel imageModel, ExpSettingsModel expSettingsModel) throws OrtException {
+        if (isActivated() && model.canFit()) {
+            try {
+                model.runInference(imageModel, expSettingsModel);
+                // double[] modProbs = model.fit(pixelModel, modelName, lagTimes, correlationMatrix);
+                // // update view
+                // view.updateFitParams(pixelModel.getFitParams());
+                // if (model.isBayes()) {
+                //     view.updateModProbs(modProbs);
+                //     view.updateHoldStatus();
+                // }
+            } catch (RuntimeException e) {
+                IJ.log(String.format("%s at pixel x=%d, y=%d"));
+            }
+        }
     }
 
     /**
@@ -56,5 +103,9 @@ public class OnnxInferenceController {
 
     public OnnxInferenceModel getModel() {
         return model;
+    }
+
+    public OnnxInferenceView getView() {
+        return view;
     }
 }

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/controller/OnnxInferenceController.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/controller/OnnxInferenceController.java
@@ -98,12 +98,12 @@ public class OnnxInferenceController {
         }
         if (!isActivated()) {
             System.out.println("Inference skipped: System is not activated.");
-            IJ.log("Inference skipped: System is not activated."); // Optional ImageJ log
+            IJ.error("Inference skipped: System is not activated."); // Optional ImageJ log
             return imagePlusResultsMap; // Return empty map
         }
         if (!model.canFit()) { // Assuming model.canFit() exists and checks readiness
             System.out.println("Inference skipped: Model cannot fit (e.g., not loaded or dimensions mismatch?).");
-            IJ.log("Inference skipped: Model cannot fit."); // Optional ImageJ log
+            IJ.error("Inference skipped: Model cannot fit."); // Optional ImageJ log
             return imagePlusResultsMap; // Return empty map
         }
 
@@ -172,12 +172,21 @@ public class OnnxInferenceController {
         return imagePlusResultsMap;
     }
 
+    public void teardownOnnxSession() {
+        this.model.closeOnnxSession();
+        this.view.updateStatus(this.model.getCurrentStatus().getDisplayLabel());
+    }
+
     /**
      * Sets the visibility of the view.
      *
      * @param b The visibility status.
      */
     public void setVisible(boolean b) {
+        // Perform teardown when closing.
+        if (!b) {
+            this.teardownOnnxSession();
+        }
         view.setVisible(b);
     }
 
@@ -210,5 +219,11 @@ public class OnnxInferenceController {
 
     public OnnxInferenceView getView() {
         return view;
+    }
+
+    // TODO: Add functionality to display windows.
+    public void btnRunInferencePressed() {
+        Map<String, ImagePlus> outputMaps = this.infer();
+
     }
 }

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/controller/OnnxInferenceController.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/controller/OnnxInferenceController.java
@@ -12,28 +12,40 @@ import ai.onnxruntime.OrtException;
 import fiji.plugin.imaging_fcs.imfcs.model.ExpSettingsModel;
 import fiji.plugin.imaging_fcs.imfcs.model.ImageModel;
 import fiji.plugin.imaging_fcs.imfcs.model.OnnxInferenceModel;
+import fiji.plugin.imaging_fcs.imfcs.model.onnx.OnnxRuntimeStatus;
 import fiji.plugin.imaging_fcs.imfcs.view.OnnxInferenceView;
 import ij.IJ;
 import ij.ImagePlus;
 
 /**
- * The OnnxInferenceController class handles the interactions between the OnnxInferneceModel and the OnnxInferenceView,
+ * The OnnxInferenceController class handles the interactions between the
+ * OnnxInferneceModel and the OnnxInferenceView,
  * managing the fitting process and updating the view based on user actions.
  */
 public class OnnxInferenceController {
     private final OnnxInferenceModel model;
     private final OnnxInferenceView view;
+    private final ImageModel imageModel;
+    private ExpSettingsModel expSettingsModel;
 
     /**
      * Constructs a new OnnxInferenceController with the given OnnxInferenceModel.
      *
      * @param model The OnnxInferenceModel instance.
      */
-    public OnnxInferenceController(OnnxInferenceModel model) {
+    public OnnxInferenceController(OnnxInferenceModel model, ImageModel imageModel, ExpSettingsModel expSettingsModel) {
         this.model = model;
         this.view = new OnnxInferenceView(this, model);
+
+        // Initialize stride values based on the view defaults.
+        this.model.setStrideX(this.view.getStrideX());
+        this.model.setStrideY(this.view.getStrideY());
+        this.model.setStrideFrames(this.view.getStrideFrames());
+
+        this.imageModel = imageModel;
+        this.expSettingsModel = expSettingsModel;
     }
-    
+
     // Load an ONNX Model.
     public void btnLoadPressed() throws OrtException {
         JFileChooser fileChooser = new JFileChooser();
@@ -43,16 +55,11 @@ public class OnnxInferenceController {
 
         int returnVal = fileChooser.showOpenDialog(null);
         if (returnVal == JFileChooser.APPROVE_OPTION) {
-             // Get the selected file object
             File selectedFile = fileChooser.getSelectedFile();
-
-            // Get the absolute path of the selected file as a String
             String filePath = selectedFile.getAbsolutePath();
 
-            // Print the file path
             System.out.println("Selected ONNX model file: " + filePath);
-            this.view.updateModelPath(filePath);
-            this.model.updateModelPath(filePath);
+            this.updateModelPath(filePath);
         }
 
         // Load the model
@@ -60,24 +67,35 @@ public class OnnxInferenceController {
 
         // Populate the Model metadata
         this.view.setModelInputMetadata(this.model.getInputMetadata());
+        this.view.updateStatus(this.model.getCurrentStatus().getDisplayLabel());
     }
-    
+
+    private void updateModelPath(String filePath) {
+        this.view.updateModelPath(filePath);
+        this.model.updateModelPath(filePath);
+    }
+
     /**
      * Performs ONNX inference using the loaded model and provided settings.
      * Always returns a map, which will be empty if inference cannot be run
      * (due to state checks) or if an error occurs during processing.
      *
-     * @param imageModel The input image data (adjust type as needed).
      * @param expSettingsModel The experiment settings (adjust type as needed).
-     * @return A Map where keys are output names and values are the resulting ImagePlus stacks.
+     * @return A Map where keys are output names and values are the resulting
+     *         ImagePlus stacks.
      *         Returns an empty map if inference is skipped or fails.
      */
-    public Map<String, ImagePlus> infer(ImageModel imageModel, ExpSettingsModel expSettingsModel) {
-
+    public Map<String, ImagePlus> infer() {
+        this.view.updateStatus(OnnxRuntimeStatus.PROCESSING.getDisplayLabel());
         // 1. Initialize the result map - Default to empty
         Map<String, ImagePlus> imagePlusResultsMap = new HashMap<>();// Use HashMap for mutability
 
         // 2. Check preconditions BEFORE the try-catch block
+        if (!this.imageModel.isImageLoaded()) {
+            System.out.println("Inference skipped: No image loaded.");
+            IJ.error("No image loaded.");
+            return imagePlusResultsMap; // Return empty map
+        }
         if (!isActivated()) {
             System.out.println("Inference skipped: System is not activated.");
             IJ.log("Inference skipped: System is not activated."); // Optional ImageJ log
@@ -93,29 +111,33 @@ public class OnnxInferenceController {
         try {
             // --- Run Inference ---
             // This might throw OrtException or potentially others
-            Map<String, float[][][]> modelOutsArray = model.runInference(imageModel, expSettingsModel);
+            Map<String, float[][][]> modelOutsArray = model.runInference(this.imageModel, this.expSettingsModel);
 
-            // --- Optional: Debug Printing (Consider removing or making conditional for production) ---
+            // --- Optional: Debug Printing (Consider removing or making conditional for
+            // production) ---
             if (modelOutsArray != null) {
-                System.out.println("Raw inference output received. Processing " + modelOutsArray.size() + " output(s).");
+                System.out
+                        .println("Raw inference output received. Processing " + modelOutsArray.size() + " output(s).");
                 for (Map.Entry<String, float[][][]> entry : modelOutsArray.entrySet()) {
                     String outputName = entry.getKey();
                     float[][][] resultArray = entry.getValue();
 
                     System.out.println("\n=== Raw Output Details: " + outputName + " ===");
-                    if (resultArray == null || resultArray.length == 0 || resultArray[0] == null || resultArray[0].length == 0 || resultArray[0][0] == null || resultArray[0][0].length == 0) {
+                    if (resultArray == null || resultArray.length == 0 || resultArray[0] == null
+                            || resultArray[0].length == 0 || resultArray[0][0] == null
+                            || resultArray[0][0].length == 0) {
                         System.out.println("  (Result array is null or empty for this output)");
                     } else {
-                        System.out.println("  Result Array Dimensions: [" + resultArray.length + "][" + resultArray[0].length + "][" + resultArray[0][0].length + "]");
+                        System.out.println("  Result Array Dimensions: [" + resultArray.length + "]["
+                                + resultArray[0].length + "][" + resultArray[0][0].length + "]");
                         // Consider limiting the full printout for large arrays in production
                         // printArrayContents(resultArray); // Maybe extract printing if complex
                     }
                 }
             } else {
-                 System.out.println("Warning: model.runInference returned a null map.");
-                 // Continue, castArrayToImagePlus should handle null input map
+                System.out.println("Warning: model.runInference returned a null map.");
+                // Continue, castArrayToImagePlus should handle null input map
             }
-
 
             // --- Convert array map to ImagePlus map ---
             // This method should internally handle null/empty input map and invalid arrays
@@ -124,7 +146,8 @@ public class OnnxInferenceController {
 
             System.out.println("Successfully converted inference results to ImagePlus map.");
         } catch (OrtException e) {
-            // Handle ONNX specific errors during runInference or potentially during setup called within it
+            // Handle ONNX specific errors during runInference or potentially during setup
+            // called within it
             System.err.println("!!! ONNX Runtime Exception during inference: " + e.getMessage());
             e.printStackTrace(); // Print stack trace for detailed debugging
             IJ.handleException(e); // Use ImageJ's exception handler for user feedback / logging
@@ -133,15 +156,16 @@ public class OnnxInferenceController {
             // Handle unexpected runtime errors during inference or conversion
             System.err.println("!!! Runtime Exception during inference/conversion: " + e.getMessage());
             e.printStackTrace();
-            // IJ.log(String.format("%s at pixel x=%d, y=%d", ...)); // Original log format needs context (pixel info) which isn't available here easily.
+            // IJ.log(String.format("%s at pixel x=%d, y=%d", ...)); // Original log format
+            // needs context (pixel info) which isn't available here easily.
             IJ.handleException(e); // Use generic ImageJ handler
             // imagePlusResultsMap remains empty
         } catch (Exception e) {
             // Catch any other possible checked exceptions as a safety net
-             System.err.println("!!! Unexpected Exception during inference/conversion: " + e.getMessage());
-             e.printStackTrace();
-             IJ.handleException(e);
-             // imagePlusResultsMap remains empty
+            System.err.println("!!! Unexpected Exception during inference/conversion: " + e.getMessage());
+            e.printStackTrace();
+            IJ.handleException(e);
+            // imagePlusResultsMap remains empty
         }
 
         // 4. Always return the map (populated if successful, empty otherwise)

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/controller/OnnxInferenceController.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/controller/OnnxInferenceController.java
@@ -81,6 +81,8 @@ public class OnnxInferenceController {
         // Populate the Model metadata
         this.view.setModelInputMetadata(this.model.getInputMetadata());
         this.view.updateStatus(this.model.getCurrentStatus().getDisplayLabel());
+        // Only enable the inference button once model is loaded.
+        this.view.enableRunInferenceButton();
     }
 
     private void updateModelPath(String filePath) {
@@ -195,6 +197,7 @@ public class OnnxInferenceController {
     public void teardownOnnxSession() {
         this.model.closeOnnxSession();
         this.view.updateStatus(this.model.getCurrentStatus().getDisplayLabel());
+        this.view.disableRunInferenceButton();
     }
 
     /**
@@ -363,6 +366,7 @@ public class OnnxInferenceController {
 
     public void startOnnxSession() {
         this.model.startOnnxSession();
+        this.view.enableRunInferenceButton();
     }
 
     public boolean canDoInference() {

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/controller/OnnxInferenceController.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/controller/OnnxInferenceController.java
@@ -144,6 +144,7 @@ public class OnnxInferenceController {
             // Assign the result directly to our return variable
             imagePlusResultsMap = model.castArrayToImagePlus(modelOutsArray);
 
+            this.view.updateStatus(OnnxRuntimeStatus.READY.getDisplayLabel());
             System.out.println("Successfully converted inference results to ImagePlus map.");
         } catch (OrtException e) {
             // Handle ONNX specific errors during runInference or potentially during setup

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/controller/OnnxInferenceController.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/controller/OnnxInferenceController.java
@@ -242,7 +242,7 @@ public class OnnxInferenceController {
     }
 
     public void btnRunInferencePressed() {
-        IJ.showStatus("Doing ONNX Inference");
+        IJ.showStatus("Executing ONNX Inference");
         new OnnxInferenceWorker(this).execute();
     }
 

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/controller/OnnxInferenceController.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/controller/OnnxInferenceController.java
@@ -229,16 +229,17 @@ public class OnnxInferenceController {
     // TODO: Add functionality to display windows.
     public void btnRunInferencePressed() {
         Map<String, ImagePlus> outputMaps = this.infer();
-        
+
         // TODO: Close existing maps before spawning new ones.
         showOnnxOutputMaps(outputMaps);
     }
 
-/**
+    /**
      * Displays each ImagePlus from the map in its own separate window.
      * Uses the map key as the initial window title.
      *
-     * @param outputMaps A map where keys are desired titles and values are ImagePlus objects.
+     * @param outputMaps A map where keys are desired titles and values are
+     *                   ImagePlus objects.
      */
     public static void showOnnxOutputMaps(Map<String, ImagePlus> outputMaps) {
         if (outputMaps == null || outputMaps.isEmpty()) {
@@ -249,8 +250,8 @@ public class OnnxInferenceController {
         // --- Optional: Basic Window Positioning Logic ---
         int initialX = 50; // Starting X position for the first window
         int initialY = 50; // Starting Y position
-        int xOffset = 30;  // How much to shift each subsequent window horizontally
-        int yOffset = 30;  // How much to shift vertically
+        int xOffset = 30; // How much to shift each subsequent window horizontally
+        int yOffset = 30; // How much to shift vertically
         int currentX = initialX;
         int currentY = initialY;
         int screenWidth = Constants.MAIN_PANEL_DIM.width;
@@ -278,9 +279,9 @@ public class OnnxInferenceController {
                 } else {
                     // If positioning is critical, might need WindowManager.getImageWindow(name)
                     // or a slight delay, but usually setLocation works.
-                    System.err.println("Warning: Could not get window reference immediately for '" + name + "' to set location.");
+                    System.err.println(
+                            "Warning: Could not get window reference immediately for '" + name + "' to set location.");
                 }
-
 
                 // 4. Calculate position for the next window (simple tiling)
                 currentX += xOffset;
@@ -293,7 +294,7 @@ public class OnnxInferenceController {
                 }
                 // If we go off the bottom, wrap back to the top (optional)
                 if (currentY + approxWindowHeight > screenHeight) {
-                     currentY = initialY;
+                    currentY = initialY;
                 }
 
             } else {

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/controller/OnnxInferenceController.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/controller/OnnxInferenceController.java
@@ -1,0 +1,60 @@
+
+package fiji.plugin.imaging_fcs.imfcs.controller;
+
+import fiji.plugin.imaging_fcs.imfcs.model.OnnxInferenceModel;
+import fiji.plugin.imaging_fcs.imfcs.view.OnnxInferenceView;
+
+/**
+ * The OnnxInferenceController class handles the interactions between the OnnxInferneceModel and the OnnxInferenceView,
+ * managing the fitting process and updating the view based on user actions.
+ */
+public class OnnxInferenceController {
+    private final OnnxInferenceModel model;
+    private final OnnxInferenceView view;
+
+    /**
+     * Constructs a new OnnxInferenceController with the given OnnxInferenceModel.
+     *
+     * @param model The OnnxInferenceModel instance.
+     */
+    public OnnxInferenceController(OnnxInferenceModel model) {
+        this.model = model;
+        this.view = new OnnxInferenceView(model);
+    }
+
+    /**
+     * Sets the visibility of the view.
+     *
+     * @param b The visibility status.
+     */
+    public void setVisible(boolean b) {
+        view.setVisible(b);
+    }
+
+    /**
+     * Dispose the view
+     */
+    public void dispose() {
+        this.view.dispose();
+    }
+
+    /**
+     * Bring the view to front
+     */
+    public void toFront() {
+        this.view.toFront();
+    }
+
+    /**
+     * Checks if the view is currently visible (activated).
+     *
+     * @return true if the view is visible, false otherwise.
+     */
+    public boolean isActivated() {
+        return view.isVisible();
+    }
+
+    public OnnxInferenceModel getModel() {
+        return model;
+    }
+}

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/controller/OnnxInferenceController.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/controller/OnnxInferenceController.java
@@ -2,6 +2,8 @@
 package fiji.plugin.imaging_fcs.imfcs.controller;
 
 import java.awt.Dimension;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
@@ -14,9 +16,11 @@ import fiji.plugin.imaging_fcs.imfcs.constants.Constants;
 import fiji.plugin.imaging_fcs.imfcs.model.ExpSettingsModel;
 import fiji.plugin.imaging_fcs.imfcs.model.ImageModel;
 import fiji.plugin.imaging_fcs.imfcs.model.OnnxInferenceModel;
+import fiji.plugin.imaging_fcs.imfcs.model.onnx.OnnxBatchModel;
 import fiji.plugin.imaging_fcs.imfcs.model.onnx.OnnxRuntimeStatus;
 import fiji.plugin.imaging_fcs.imfcs.utils.ApplyCustomLUT;
 import fiji.plugin.imaging_fcs.imfcs.view.OnnxInferenceView;
+import fiji.plugin.imaging_fcs.imfcs.view.OnnxBatchView;
 import fiji.plugin.imaging_fcs.imfcs.model.OnnxInferenceWorker;
 import ij.IJ;
 import ij.ImagePlus;
@@ -33,6 +37,9 @@ public class OnnxInferenceController {
     private final OnnxInferenceView view;
     private final ImageModel imageModel;
     private ExpSettingsModel expSettingsModel;
+    private OnnxBatchView batchView;
+    private OnnxBatchModel batchModel;
+    private OnnxBatchController batchController;
 
     // Keep track of window positions globally or pass state if needed
     private static int nextX = 50;
@@ -49,6 +56,9 @@ public class OnnxInferenceController {
     public OnnxInferenceController(OnnxInferenceModel model, ImageModel imageModel, ExpSettingsModel expSettingsModel) {
         this.model = model;
         this.view = new OnnxInferenceView(this, model);
+        this.batchModel = new OnnxBatchModel();
+        this.batchController = new OnnxBatchController(this.batchModel);
+        this.batchView = this.batchController.getView();
 
         // Initialize stride values based on the view defaults.
         this.model.setStrideX(this.view.getStrideX());
@@ -126,10 +136,32 @@ public class OnnxInferenceController {
         this.view.disableRunInferenceButton();
 
         // 3. Perform inference and conversion within a try-catch block
+        int batchSize = this.batchModel.isBatchingEnabled()
+                ? this.batchModel.getBatchSize()
+                : 1;
+
+        // If batching is disabled, we force workers to 0/1 regardless of the field
+        // value.
+        int numPrefetchWorkers = this.batchModel.isBatchingEnabled()
+                ? this.batchModel.getNumPrefetchWorkers()
+                : 0;
+
+        System.out.printf("Inference initiated with Batch Size: %d, Prefetch Workers: %d\n",
+                batchSize, numPrefetchWorkers);
+        // ---------------------------------------
+
+        // Disable the RunInference button.
+        this.view.disableRunInferenceButton();
+
+        // 3. Perform inference and conversion within a try-catch block
         try {
             // --- Run Inference ---
-            // This might throw OrtException or potentially others
-            Map<String, float[][][]> modelOutsArray = model.runInference(this.imageModel, this.expSettingsModel);
+            // Pass the dynamically retrieved parameters
+            Map<String, float[][][]> modelOutsArray = model.runInference(
+                    this.imageModel,
+                    this.expSettingsModel,
+                    batchSize,
+                    numPrefetchWorkers);
 
             // --- Optional: Debug Printing (Consider removing or making conditional for
             // production) ---
@@ -412,5 +444,17 @@ public class OnnxInferenceController {
 
             IJ.saveAsTiff(imp, path + "_onnx" + title + ".tiff");
         }
+    }
+
+    /**
+     * Handles the press of the 'Batch Settings' button, typically opening a
+     * separate configuration window.
+     */
+    public ItemListener tbBatchSettingsPressed() {
+        return (ItemEvent ev) -> {
+            boolean selected = (ev.getStateChange() == ItemEvent.SELECTED);
+            this.batchView.setVisible(selected);
+            this.batchView.toFront();
+        };
     }
 }

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/controller/OnnxInferenceController.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/controller/OnnxInferenceController.java
@@ -405,9 +405,10 @@ public class OnnxInferenceController {
         System.out.println("Finished displaying/updating windows.");
     }
 
-    public void startOnnxSession() {
-        this.model.startOnnxSession();
-        this.view.enableRunInferenceButton();
+    public void startOnnxSession() throws OrtException {
+        // this.model.startOnnxSession();
+        // this.view.enableRunInferenceButton();
+        this.loadModel();
     }
 
     public boolean canDoInference() {

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/controller/OnnxInferenceController.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/controller/OnnxInferenceController.java
@@ -84,6 +84,12 @@ public class OnnxInferenceController {
             System.out.println("Selected ONNX model file: " + filePath);
             this.updateModelPath(filePath);
         }
+        
+        loadModel();
+    }
+
+    private void loadModel() throws OrtException {
+        this.teardownOnnxSession();
 
         // Load the model
         this.model.loadOnnxModel(this.view.getUseGPU());
@@ -93,6 +99,7 @@ public class OnnxInferenceController {
         this.view.updateStatus(this.model.getCurrentStatus().getDisplayLabel());
         // Only enable the inference button once model is loaded.
         this.view.enableRunInferenceButton();
+
     }
 
     private void updateModelPath(String filePath) {

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/controller/OnnxInferenceController.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/controller/OnnxInferenceController.java
@@ -99,7 +99,7 @@ public class OnnxInferenceController {
         this.view.updateStatus(this.model.getCurrentStatus().getDisplayLabel());
         // Only enable the inference button once model is loaded.
         this.view.enableRunInferenceButton();
-
+        this.view.updateDevice(this.model.getGpu() ? "GPU" : "CPU");
     }
 
     private void updateModelPath(String filePath) {
@@ -463,6 +463,15 @@ public class OnnxInferenceController {
             boolean selected = (ev.getStateChange() == ItemEvent.SELECTED);
             this.batchView.setVisible(selected);
             this.batchView.toFront();
+        };
+    }
+
+    public ItemListener cbUseGpuToggled() { 
+        return (ItemEvent ev) -> {
+            // Check if a model is actually loaded before flagging for re-initialization
+            if (this.model.getCurrentStatus() != OnnxRuntimeStatus.NO_MODEL_LOADED) {
+                this.view.updateDevice("Click Init Model to apply change");
+            }
         };
     }
 }

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/OnnxInferenceModel.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/OnnxInferenceModel.java
@@ -150,6 +150,7 @@ public class OnnxInferenceModel {
      */
     public boolean canFit() {
         if (this.currentStatus == OnnxRuntimeStatus.READY && this.deepLearningProcessor != null) {
+            // TODO: This check seems extraneous
             if (this.deepLearningProcessor.isOnnxSessionStarted()) {
                 return true;
             } else {
@@ -300,9 +301,27 @@ public class OnnxInferenceModel {
             try {
                 this.deepLearningProcessor.close();
                 System.out.println("\nProcessor resources closed.");
-                this.currentStatus = OnnxRuntimeStatus.NO_MODEL_LOADED;
+                this.currentStatus = OnnxRuntimeStatus.MODEL_SELECTED;
             } catch (OrtException e) {
                 System.err.println("Error closing processor resources: " + e.getMessage());
+                e.printStackTrace();
+            }
+        }
+    }
+
+    public void startOnnxSession() {
+        if (getCurrentStatus() == OnnxRuntimeStatus.NO_MODEL_LOADED) {
+            System.err.println("No ONNX model loaded, nothing to initialize.");
+            IJ.error("No ONNX model loaded, cannot initialize.");
+        }
+
+        if (this.deepLearningProcessor != null) {
+            try {
+                this.deepLearningProcessor.getOnnxPredictor().create_session();
+                System.out.println("\nOnnx inference session created.");
+                this.currentStatus = OnnxRuntimeStatus.READY;
+            } catch (OrtException e) {
+                System.err.println("Error creating ONNX inference session: " + e.getMessage());
                 e.printStackTrace();
             }
         }

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/OnnxInferenceModel.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/OnnxInferenceModel.java
@@ -1,0 +1,125 @@
+package fiji.plugin.imaging_fcs.imfcs.model;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.InvalidPathException;
+
+import ij.IJ;  // Import ImageJ
+import ij.ImagePlus;
+import ai.onnxruntime.OrtException;
+import java.util.Map;
+import fiji.plugin.imaging_fcs.imfcs.model.onnx.DeepLearningProcessor;
+
+public class OnnxInferenceModel {
+    private int strideX;
+    private int strideY;
+    private int strideFrames;
+    private DeepLearningProcessor deepLearningProcessor;
+    private BleachCorrectionModel bleachCorrectionModel;
+    private boolean onnxModelReady = false;
+    
+    /**
+     * Constructs a ONNX inference model with references to the experimental settings.
+     *
+     * @param expSettingsModel the experimental settings model.
+     */
+    public OnnxInferenceModel(BleachCorrectionModel bleachCorrectionModel) {
+        this.bleachCorrectionModel = bleachCorrectionModel;
+        this.onnxModelReady = false;
+    }
+
+    private boolean validateModelPath(String onnxModelPath) {
+        try {
+            if (!Files.exists(Paths.get(onnxModelPath))) {
+                IJ.error("Error: ONNX model does not exist: " + onnxModelPath);
+                return false;
+            }
+            if (!onnxModelPath.toLowerCase().endsWith(".onnx")) {
+                IJ.error("Error: ONNX file must have .onnx extension: " + onnxModelPath);
+                return false;
+            }
+        } catch (InvalidPathException e) {
+            IJ.error("Error: Invalid file path: " + e.getMessage());
+            return false;
+        }
+        return true;
+    }
+
+    public boolean loadOnnxModel(String onnxModelPath, boolean useGpu) throws OrtException {
+        // File validation
+        if (!validateModelPath(onnxModelPath)) {
+            IJ.error("Error loading ONNX model.");
+            throw new Error("Invalid paths provided for the ONNX model.");
+        }
+
+        this.deepLearningProcessor = new DeepLearningProcessor(this.bleachCorrectionModel, useGpu);
+        this.deepLearningProcessor.loadOnnxModel(onnxModelPath);
+        this.onnxModelReady = true;
+        return true;
+    }
+
+    public void runInference(ImageModel imageModel, ExpSettingsModel expSettingsModel) {
+        if (!this.onnxModelReady) {
+            IJ.error("ONNX Model needs to be loaded for inference.");
+            throw new Error("ONNX Model is not loaded.");
+        }
+        try {
+            ImagePlus imp = imageModel.getImage();
+
+            // Create the DeepLearningProcessor
+            this.deepLearningProcessor.loadImage(imp);
+
+            // Process the image - This now returns a Map
+            Map<String, float[][][]> resultsMap = this.deepLearningProcessor.processImage(
+                    strideX, strideY, strideFrames,
+                    expSettingsModel.getFirstFrame(), expSettingsModel.getLastFrame());
+
+            System.out.println("Processing Complete. Results:");
+            for (Map.Entry<String, float[][][]> entry : resultsMap.entrySet()) {
+                String outputName = entry.getKey();
+                float[][][] resultArray = entry.getValue(); // Get the specific result array for this output
+
+                System.out.println("\n=== Output Name: " + outputName + " ===");
+
+                // Defensive check if the array dimensions are valid before trying to access elements
+                if (resultArray == null || resultArray.length == 0 || resultArray[0].length == 0 || resultArray[0][0].length == 0) {
+                    System.out.println(" (Result array is null or empty for this output)");
+                    continue; // Skip to the next output name
+                }
+
+                System.out.println("Result Array Dimensions: [" + resultArray.length + "][" + resultArray[0].length + "][" + resultArray[0][0].length + "]");
+                System.out.println("--------------------------");
+
+                // Print the contents of this specific resultArray
+                // (Using the original printing logic, now applied per output)
+                for (int x = 0; x < resultArray.length; x++) {
+                    for (int y = 0; y < resultArray[0].length; y++) {
+                        System.out.print("  ["); // Indent slightly for readability
+                        for (int frame = 0; frame < resultArray[0][0].length; frame++) {
+                            System.out.print(resultArray[x][y][frame] + (frame < resultArray[0][0].length - 1 ? ", " : ""));
+                        }
+                        System.out.print("] ");
+                    }
+                    System.out.println(); // Newline after each row (all y values for a given x)
+                }
+            }
+
+        } catch (OrtException e) {
+            System.err.println("Error during ONNX processing: " + e.getMessage());
+            e.printStackTrace();
+            System.exit(1);
+        } finally {
+             // Ensure processor resources are always closed if initialized
+            if (this.deepLearningProcessor != null) {
+                try {
+                    this.deepLearningProcessor.close();
+                    System.out.println("\nProcessor resources closed.");
+                } catch (OrtException e) {
+                    System.err.println("Error closing processor resources: " + e.getMessage());
+                    e.printStackTrace();
+                }
+            }
+        }
+    }
+}
+

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/OnnxInferenceModel.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/OnnxInferenceModel.java
@@ -326,4 +326,8 @@ public class OnnxInferenceModel {
             }
         }
     }
+
+    public boolean getGpu() {
+        return this.useGpu;
+    }
 }

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/OnnxInferenceModel.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/OnnxInferenceModel.java
@@ -6,9 +6,15 @@ import java.nio.file.InvalidPathException;
 
 import ij.IJ;  // Import ImageJ
 import ij.ImagePlus;
+import ij.ImageStack;
+import ij.process.FloatProcessor;
 import ai.onnxruntime.OrtException;
+
+import java.util.HashMap;
 import java.util.Map;
 import fiji.plugin.imaging_fcs.imfcs.model.onnx.DeepLearningProcessor;
+import fiji.plugin.imaging_fcs.imfcs.model.onnx.InputMetadata;
+import fiji.plugin.imaging_fcs.imfcs.model.onnx.OnnxRuntimeStatus;
 
 public class OnnxInferenceModel {
     private int strideX;
@@ -16,16 +22,24 @@ public class OnnxInferenceModel {
     private int strideFrames;
     private DeepLearningProcessor deepLearningProcessor;
     private BleachCorrectionModel bleachCorrectionModel;
-    private boolean onnxModelLoaded = false;
+
+    // Properties dependent on the loaded model, updated from view using listeners.
+    // Required for communication between the controller and the model.
+    private int modelInputX;
+    private int modelInputY;
+    private int modelInputFrames;
+    private String modelPath;
+    private boolean useGpu;
+    private OnnxRuntimeStatus currentStatus = OnnxRuntimeStatus.NO_MODEL_LOADED; 
     
     /**
      * Constructs a ONNX inference model with references to the experimental settings.
      *
      * @param expSettingsModel the experimental settings model.
      */
-    public OnnxInferenceModel(BleachCorrectionModel bleachCorrectionModel) {
+    public OnnxInferenceModel(BleachCorrectionModel bleachCorrectionModel, boolean UseGpu) {
         this.bleachCorrectionModel = bleachCorrectionModel;
-        this.onnxModelLoaded = false;
+        this.useGpu = UseGpu;
     }
 
     private boolean validateModelPath(String onnxModelPath) {
@@ -45,25 +59,34 @@ public class OnnxInferenceModel {
         return true;
     }
 
-    public boolean loadOnnxModel(String onnxModelPath, boolean useGpu) throws OrtException {
+    public boolean loadOnnxModel(boolean useGpu) throws OrtException {
         // File validation
-        if (!validateModelPath(onnxModelPath)) {
+        if (!validateModelPath(this.modelPath)) {
+            this.currentStatus = OnnxRuntimeStatus.ERROR_LOADING;
             IJ.error("Error loading ONNX model.");
             throw new Error("Invalid paths provided for the ONNX model.");
         }
 
+        // Model selected, but not yet loaded.
+        this.currentStatus = OnnxRuntimeStatus.MODEL_SELECTED;
+
         this.deepLearningProcessor = new DeepLearningProcessor(this.bleachCorrectionModel, useGpu);
-        this.deepLearningProcessor.loadOnnxModel(onnxModelPath);
-        this.onnxModelLoaded = true;
+        this.deepLearningProcessor.loadOnnxModel(this.modelPath);
+
+        // Update internal state.
+        this.useGpu = useGpu;
+        this.currentStatus = OnnxRuntimeStatus.READY;
+
         return true;
     }
 
     public Map<String, float[][][]> runInference(ImageModel imageModel, ExpSettingsModel expSettingsModel) throws OrtException {
-        if (!this.onnxModelLoaded) {
+        if (this.currentStatus != OnnxRuntimeStatus.READY) {
             IJ.error("ONNX Model needs to be loaded for inference.");
             throw new Error("ONNX Model is not loaded.");
         }
         try {
+            this.currentStatus = OnnxRuntimeStatus.PROCESSING;
             ImagePlus imp = imageModel.getImage();
 
             // Create the DeepLearningProcessor
@@ -103,9 +126,11 @@ public class OnnxInferenceModel {
                     System.out.println(); // Newline after each row (all y values for a given x)
                 }
             }
+            this.currentStatus = OnnxRuntimeStatus.READY;
             return resultsMap;
         } catch (OrtException e) {
             System.err.println("Error during ONNX processing: " + e.getMessage());
+            this.currentStatus = OnnxRuntimeStatus.ERROR_PROCESSING;
             e.printStackTrace();
             // Instead of System.exit, re-throw the exception (or wrap it)
             throw e; // Let the caller handle the OrtException
@@ -129,7 +154,7 @@ public class OnnxInferenceModel {
      * @return true if model is loaded and ready for inference.
      */
     public boolean canFit() {
-        if (this.onnxModelLoaded && this.deepLearningProcessor != null) {
+        if (this.currentStatus == OnnxRuntimeStatus.READY && this.deepLearningProcessor != null) {
             if (this.deepLearningProcessor.isOnnxSessionStarted()) {
                 return true;
             } else {
@@ -140,5 +165,113 @@ public class OnnxInferenceModel {
         return false;
     }
 
+    public void updateModelPath(String filePath) {
+        this.modelPath = filePath;
+    }
+
+    public InputMetadata getInputMetadata() {
+        return this.deepLearningProcessor.getInputMetadata();
+    }
+
+    public Map<String, ImagePlus> castArrayToImagePlus(Map<String, float[][][]> inferenceResults) {
+
+        // 1. Initialize the map to store the resulting ImagePlus objects.
+        Map<String, ImagePlus> imagePlusMap = new HashMap<>();
+
+        // 2. Handle null or empty input map immediately.
+        if (inferenceResults == null || inferenceResults.isEmpty()) {
+            System.out.println("Input map for castArrayToImagePlus is null or empty. Returning empty map.");
+            return imagePlusMap;
+        }
+
+        // 3. Iterate through each entry (output name -> 3D float array) in the input map.
+        for (Map.Entry<String, float[][][]> entry : inferenceResults.entrySet()) {
+            String outputName = entry.getKey();       // The identifier/name for this image stack.
+            float[][][] dataArray = entry.getValue(); // The 3D array [WIDTH][HEIGHT][FRAMES].
+
+            // 4. --- Input Validation for the current dataArray ---
+            // Check if the array itself is null.
+            if (dataArray == null) {
+                 System.err.println("Skipping conversion for output '" + outputName + "': Input data array is null.");
+                 continue; // Move to the next entry in the map.
+            }
+            // Check if the first dimension (WIDTH) is valid.
+            if (dataArray.length == 0) {
+                 System.err.println("Skipping conversion for output '" + outputName + "': Width dimension (dataArray.length) is 0.");
+                 continue;
+            }
+            // Check if the second dimension (HEIGHT) is valid. Assumes rectangular structure.
+            // Need to check if dataArray[0] is null before accessing its length.
+            if (dataArray[0] == null || dataArray[0].length == 0) {
+                System.err.println("Skipping conversion for output '" + outputName + "': Height dimension (dataArray[0].length) is 0 or dataArray[0] is null.");
+                continue;
+            }
+            // Check if the third dimension (FRAMES) is valid. Assumes consistent depth.
+            // Need to check if dataArray[0][0] is null before accessing its length.
+            if (dataArray[0][0] == null || dataArray[0][0].length == 0) {
+                System.err.println("Skipping conversion for output '" + outputName + "': Frames dimension (dataArray[0][0].length) is 0 or dataArray[0][0] is null.");
+                continue;
+            }
+            // --- End Input Validation ---
+
+            // 5. Determine the dimensions from the validated array.
+            int width = dataArray.length;          // Width from the first dimension.
+            int height = dataArray[0].length;       // Height from the second dimension.
+            int nFrames = dataArray[0][0].length;   // Number of frames/slices from the third dimension.
+
+            // 6. Create a new ImageJ ImageStack to hold the individual 2D slices (frames).
+            // The stack is defined by the width and height of each slice.
+            ImageStack imageStack = new ImageStack(width, height);
+
+            // 7. Iterate through each frame (which corresponds to a slice in the ImageStack).
+            for (int frameIndex = 0; frameIndex < nFrames; frameIndex++) {
+
+                // 8. Create a 1D float array to hold the pixel data for the *current* frame/slice.
+                // ImageJ processors expect pixel data as a flat 1D array. Size is width * height.
+                float[] slicePixels = new float[width * height];
+
+                // 9. Populate the 1D slicePixels array from the 3D dataArray for the current frameIndex.
+                // ImageJ's standard pixel order in 1D arrays is row-by-row.
+                // So, the pixel at (x, y) should be at index (y * width + x) in the 1D array.
+                for (int y = 0; y < height; y++) {
+                    for (int x = 0; x < width; x++) {
+                        // Calculate the index in the 1D target array.
+                        int targetIndex = y * width + x;
+                        // Get the pixel value from the source 3D array: dataArray[WIDTH][HEIGHT][FRAME]
+                        float pixelValue = dataArray[x][y][frameIndex];
+                        // Assign the value to the correct position in the 1D slice array.
+                        slicePixels[targetIndex] = pixelValue;
+                    }
+                } // End of loops for x and y (pixel population for one slice)
+
+                // 10. Create an ImageJ FloatProcessor for this single slice.
+                // This represents one 2D grayscale image with 32-bit float data.
+                FloatProcessor floatProcessor = new FloatProcessor(width, height, slicePixels);
+
+                // 11. Add the created FloatProcessor (slice) to the ImageStack.
+                // It's good practice to give each slice a label, typically its 1-based index.
+                imageStack.addSlice(String.valueOf(frameIndex + 1), floatProcessor);
+
+            } // End of loop through frames (all slices added to imageStack)
+
+            // 12. Create the final ImagePlus object.
+            // It uses the original outputName as its title and contains the populated ImageStack.
+            ImagePlus imagePlus = new ImagePlus(outputName, imageStack);
+
+            // 13. Add the newly created ImagePlus object to the result map, using the
+            // original output name as the key.
+            imagePlusMap.put(outputName, imagePlus);
+
+            System.out.println("Successfully converted output '" + outputName + "' to ImagePlus (" + width + "x" + height + "x" + nFrames + ").");
+
+        } // End of loop through the input map entries
+
+        // 14. Return the map containing the generated ImagePlus objects.
+        return imagePlusMap;
+    }
+
+    public OnnxRuntimeStatus getCurrentStatus() {
+        return this.currentStatus;
+    }
 }
 

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/OnnxInferenceModel.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/OnnxInferenceModel.java
@@ -140,18 +140,7 @@ public class OnnxInferenceModel {
             e.printStackTrace();
             // Instead of System.exit, re-throw the exception (or wrap it)
             throw e; // Let the caller handle the OrtException
-        } finally {
-            // Ensure processor resources are always closed if initialized
-            if (this.deepLearningProcessor != null) {
-                try {
-                    this.deepLearningProcessor.close();
-                    System.out.println("\nProcessor resources closed.");
-                } catch (OrtException e) {
-                    System.err.println("Error closing processor resources: " + e.getMessage());
-                    e.printStackTrace();
-                }
-            }
-        }
+        } 
     }
 
     /**
@@ -304,5 +293,18 @@ public class OnnxInferenceModel {
     public void setStrideFrames(String strideFrames) {
         this.strideFrames = Integer.parseInt(strideFrames);
         System.out.printf("Updated model strideFrames %d", this.strideFrames);
+    }
+
+    public void closeOnnxSession() {
+        if (this.deepLearningProcessor != null) {
+            try {
+                this.deepLearningProcessor.close();
+                System.out.println("\nProcessor resources closed.");
+                this.currentStatus = OnnxRuntimeStatus.NO_MODEL_LOADED;
+            } catch (OrtException e) {
+                System.err.println("Error closing processor resources: " + e.getMessage());
+                e.printStackTrace();
+            }
+        }
     }
 }

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/OnnxInferenceModel.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/OnnxInferenceModel.java
@@ -347,4 +347,9 @@ public class OnnxInferenceModel {
     public boolean getGpu() {
         return this.useGpu;
     }
+
+
+    public void setCurrentStatus(OnnxRuntimeStatus status) {
+        this.currentStatus = status;
+    }
 }

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/OnnxInferenceModel.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/OnnxInferenceModel.java
@@ -112,7 +112,7 @@ public class OnnxInferenceModel {
             // Process the image - This now returns a Map
             Map<String, float[][][]> resultsMap = this.deepLearningProcessor.processImage(
                     strideX, strideY, strideFrames,
-                    expSettingsModel.getFirstFrame(), expSettingsModel.getLastFrame());
+                    expSettingsModel.getFirstFrame(), expSettingsModel.getLastFrame(), batchSize);
 
             // System.out.println("Processing Complete. Results:");
             // for (Map.Entry<String, float[][][]> entry : resultsMap.entrySet()) {

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/OnnxInferenceModel.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/OnnxInferenceModel.java
@@ -60,7 +60,7 @@ public class OnnxInferenceModel {
         return true;
     }
 
-    public boolean loadOnnxModel(boolean useGpu) throws OrtException {
+    public void loadOnnxModel(boolean useGpu) throws OrtException {
         // File validation
         if (!validateModelPath(this.modelPath)) {
             this.currentStatus = OnnxRuntimeStatus.ERROR_LOADING;
@@ -77,8 +77,6 @@ public class OnnxInferenceModel {
         // Update internal state.
         this.useGpu = useGpu;
         this.currentStatus = OnnxRuntimeStatus.READY;
-
-        return true;
     }
 
     public Map<String, float[][][]> runInference(ImageModel imageModel, ExpSettingsModel expSettingsModel,

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/OnnxInferenceModel.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/OnnxInferenceModel.java
@@ -81,12 +81,27 @@ public class OnnxInferenceModel {
         return true;
     }
 
-    public Map<String, float[][][]> runInference(ImageModel imageModel, ExpSettingsModel expSettingsModel)
+    public Map<String, float[][][]> runInference(ImageModel imageModel, ExpSettingsModel expSettingsModel,
+            int batchSize, int numPrefetchWorkers)
             throws OrtException {
         if (this.currentStatus != OnnxRuntimeStatus.READY) {
             IJ.error("ONNX Model needs to be loaded for inference.");
             throw new Error("ONNX Model is not loaded.");
         }
+
+        if (numPrefetchWorkers > 1) {
+            throw new UnsupportedOperationException("Feature incomplete. Contact assistance.");
+        } else if (numPrefetchWorkers >= 0) {
+            return runInferenceSynchronous(imageModel, expSettingsModel, batchSize);
+        } else {
+            throw new IllegalArgumentException("Invalid numPrefectchWorkers, must be > 0.");
+        }
+    }
+
+    public Map<String, float[][][]> runInferenceSynchronous(
+            ImageModel imageModel,
+            ExpSettingsModel expSettingsModel,
+            int batchSize) throws OrtException {
         try {
             this.currentStatus = OnnxRuntimeStatus.PROCESSING;
             ImagePlus imp = imageModel.getImage();
@@ -99,39 +114,43 @@ public class OnnxInferenceModel {
                     strideX, strideY, strideFrames,
                     expSettingsModel.getFirstFrame(), expSettingsModel.getLastFrame());
 
-            System.out.println("Processing Complete. Results:");
-            for (Map.Entry<String, float[][][]> entry : resultsMap.entrySet()) {
-                String outputName = entry.getKey();
-                float[][][] resultArray = entry.getValue(); // Get the specific result array for this output
-
-                System.out.println("\n=== Output Name: " + outputName + " ===");
-
-                // Defensive check if the array dimensions are valid before trying to access
-                // elements
-                if (resultArray == null || resultArray.length == 0 || resultArray[0].length == 0
-                        || resultArray[0][0].length == 0) {
-                    System.out.println(" (Result array is null or empty for this output)");
-                    continue; // Skip to the next output name
-                }
-
-                System.out.println("Result Array Dimensions: [" + resultArray.length + "][" + resultArray[0].length
-                        + "][" + resultArray[0][0].length + "]");
-                System.out.println("--------------------------");
-
-                // Print the contents of this specific resultArray
-                // (Using the original printing logic, now applied per output)
-                for (int x = 0; x < resultArray.length; x++) {
-                    for (int y = 0; y < resultArray[0].length; y++) {
-                        System.out.print("  ["); // Indent slightly for readability
-                        for (int frame = 0; frame < resultArray[0][0].length; frame++) {
-                            System.out.print(
-                                    resultArray[x][y][frame] + (frame < resultArray[0][0].length - 1 ? ", " : ""));
-                        }
-                        System.out.print("] ");
-                    }
-                    System.out.println(); // Newline after each row (all y values for a given x)
-                }
-            }
+            // System.out.println("Processing Complete. Results:");
+            // for (Map.Entry<String, float[][][]> entry : resultsMap.entrySet()) {
+            // String outputName = entry.getKey();
+            // float[][][] resultArray = entry.getValue(); // Get the specific result array
+            // for this output
+            //
+            // System.out.println("\n=== Output Name: " + outputName + " ===");
+            //
+            // // Defensive check if the array dimensions are valid before trying to access
+            // // elements
+            // if (resultArray == null || resultArray.length == 0 || resultArray[0].length
+            // == 0
+            // || resultArray[0][0].length == 0) {
+            // System.out.println(" (Result array is null or empty for this output)");
+            // continue; // Skip to the next output name
+            // }
+            //
+            // System.out.println("Result Array Dimensions: [" + resultArray.length + "][" +
+            // resultArray[0].length
+            // + "][" + resultArray[0][0].length + "]");
+            // System.out.println("--------------------------");
+            //
+            // // Print the contents of this specific resultArray
+            // // (Using the original printing logic, now applied per output)
+            // for (int x = 0; x < resultArray.length; x++) {
+            // for (int y = 0; y < resultArray[0].length; y++) {
+            // System.out.print(" ["); // Indent slightly for readability
+            // for (int frame = 0; frame < resultArray[0][0].length; frame++) {
+            // System.out.print(
+            // resultArray[x][y][frame] + (frame < resultArray[0][0].length - 1 ? ", " :
+            // ""));
+            // }
+            // System.out.print("] ");
+            // }
+            // System.out.println(); // Newline after each row (all y values for a given x)
+            // }
+            // }
             this.currentStatus = OnnxRuntimeStatus.READY;
             return resultsMap;
         } catch (OrtException e) {
@@ -140,7 +159,7 @@ public class OnnxInferenceModel {
             e.printStackTrace();
             // Instead of System.exit, re-throw the exception (or wrap it)
             throw e; // Let the caller handle the OrtException
-        } 
+        }
     }
 
     /**

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/OnnxInferenceWorker.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/OnnxInferenceWorker.java
@@ -1,0 +1,73 @@
+package fiji.plugin.imaging_fcs.imfcs.model;
+
+import fiji.plugin.imaging_fcs.imfcs.controller.OnnxInferenceController;
+import ij.IJ;
+import ij.ImagePlus;
+
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import javax.swing.*;
+
+/**
+ * CorrelationWorker performs correlation on a given ROI using an
+ * ImageController.
+ * It ensures that only one correlation task is active at a time by canceling
+ * any
+ * previously running instance. The worker passes its cancellation status to the
+ * correlation process so that it can exit early if needed.
+ */
+public class OnnxInferenceWorker extends SwingWorker<Map<String, ImagePlus>, Void> {
+    // Track the current running instance.
+    private static volatile OnnxInferenceWorker currentInstance;
+
+    // References to the objects needed for correlation.
+    private final OnnxInferenceController onnxInferenceController;
+
+    /**
+     * Creates a new OnnxInferenceWorker
+     *
+     * @param imageController the controller performing correlation
+     */
+    public OnnxInferenceWorker(OnnxInferenceController onnxInferenceController) {
+        this.onnxInferenceController = onnxInferenceController;
+        currentInstance = this;
+    }
+
+    /**
+     * Performs the inference in a background thread.
+     *
+     * @return null upon completion
+     * @throws Exception if an error occurs during correlation
+     */
+    @Override
+    protected Map<String, ImagePlus> doInBackground() throws Exception {
+        return this.onnxInferenceController.infer();
+    }
+
+    /**
+     * Updates the UI when the task is finished.
+     * If the task was cancelled, the status is updated accordingly.
+     * The static reference to the current instance is cleared.
+     */
+    @Override
+    protected void done() {
+        try {
+            // Plot the output maps.
+            Map<String, ImagePlus> outputMaps = get();
+            OnnxInferenceController.showOnnxOutputMaps(outputMaps);
+        } catch (InterruptedException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		} catch (ExecutionException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		} finally {
+            synchronized (OnnxInferenceWorker.class) {
+                if (currentInstance == this) {
+                    currentInstance = null; // Clear reference when done
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/ChunkGenerator.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/ChunkGenerator.java
@@ -58,10 +58,20 @@ public class ChunkGenerator {
     }
 
     public float[][][] generateResultArray() {
+        System.out.println(imageDimX);
+        System.out.println(imageDimY);
+        System.out.println(imageDimFrames);
+        System.out.println(strideX);
+        System.out.println(strideY);
+        System.out.println(strideFrames);
+
         int resultDimX = (imageDimX - modelInputX) / strideX + 1;
         int resultDimY = (imageDimY - modelInputY) / strideY + 1;
         int resultDimFrames = (imageDimFrames - modelInputFrames) / strideFrames + 1;
-
+        
+        System.out.println(resultDimX);
+        System.out.println(resultDimY);
+        System.out.println(resultDimFrames);
         return new float[resultDimX][resultDimY][resultDimFrames];
     }
     

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/ChunkGenerator.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/ChunkGenerator.java
@@ -1,0 +1,114 @@
+package fiji.plugin.imaging_fcs.imfcs.model.onnx;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import fiji.plugin.imaging_fcs.imfcs.utils.Pair;
+
+public class ChunkGenerator {
+    private final int imageDimX;
+    private final int imageDimY;
+    private final int imageDimFrames;
+    private final int modelInputX;
+    private final int modelInputY;
+    private final int modelInputFrames;
+    private final int strideX;
+    private final int strideY;
+    private final int strideFrames;
+
+    public ChunkGenerator(int imageDimX, int imageDimY, int imageDimFrames,
+                   int modelInputX, int modelInputY, int modelInputFrames,
+                   int strideX, int strideY, int strideFrames) {
+
+        this.imageDimX = imageDimX;
+        this.imageDimY = imageDimY;
+        this.imageDimFrames = imageDimFrames;
+        this.modelInputX = modelInputX;
+        this.modelInputY = modelInputY;
+        this.modelInputFrames = modelInputFrames;
+        this.strideX = strideX;
+        this.strideY = strideY;
+        this.strideFrames = strideFrames;
+    }
+
+    public List<ChunkIndices> generateChunkIndicesList() {
+        List<ChunkIndices> indicesList = new ArrayList<>();
+
+        for (int x = 0; x <= imageDimX - modelInputX; x += strideX) {
+            for (int y = 0; y <= imageDimY - modelInputY; y += strideY) {
+                for (int frame = 0; frame <= imageDimFrames - modelInputFrames; frame += strideFrames) {
+                    int endX = x + modelInputX;
+                    int endY = y + modelInputY;
+                    int endFrame = frame + modelInputFrames;
+                    indicesList.add(new ChunkIndices(x, endX, y, endY, frame, endFrame));
+                }
+            }
+        }
+        return indicesList;
+    }
+
+
+    public ResultIndices mapChunkIndicesToResultIndices(ChunkIndices chunkIndices) {
+        int resultX = chunkIndices.startX / strideX;
+        int resultY = chunkIndices.startY / strideY;
+        int resultFrame = chunkIndices.startFrame / strideFrames;
+        return new ResultIndices(resultX, resultY, resultFrame);
+    }
+
+    public float[][][] generateResultArray() {
+        int resultDimX = (imageDimX - modelInputX) / strideX + 1;
+        int resultDimY = (imageDimY - modelInputY) / strideY + 1;
+        int resultDimFrames = (imageDimFrames - modelInputFrames) / strideFrames + 1;
+
+        return new float[resultDimX][resultDimY][resultDimFrames];
+    }
+    
+    public Iterator<Pair<float[][][], ResultIndices>> getChunkIterator(float[][][] imageArr) {
+      return new ChunkIterator(imageArr, this.modelInputX, this.modelInputY, this.modelInputFrames);
+    }
+
+    private class ChunkIterator implements Iterator<Pair<float[][][], ResultIndices>> {
+      private final Iterator<ChunkIndices> indicesIterator;
+      private final float[][][] imageArr;
+      private final int modelInputX;
+      private final int modelInputY;
+      private final int modelInputFrames;
+
+      public ChunkIterator(float[][][] imageArr, int modelInputX, int modelInputY, int modelInputFrames) {
+          this.indicesIterator = generateChunkIndicesList().iterator();
+          this.imageArr = imageArr;
+          this.modelInputX = modelInputX;
+          this.modelInputY = modelInputY;
+          this.modelInputFrames = modelInputFrames;
+      }
+
+      @Override
+      public boolean hasNext() {
+          return indicesIterator.hasNext();
+      }
+
+      @Override
+      public Pair<float[][][], ResultIndices> next() {
+          if (!hasNext()) {
+              throw new NoSuchElementException();
+          }
+
+          ChunkIndices chunkIndices = indicesIterator.next();
+          ResultIndices resultIndices = mapChunkIndicesToResultIndices(chunkIndices);
+
+          // Extract the chunk
+          float[][][] chunk = new float[this.modelInputFrames][this.modelInputX][this.modelInputY];
+          for (int x = 0; x < this.modelInputX; x++) {
+              for (int y = 0; y < this.modelInputY; y++) {
+                  for (int frame = 0; frame < this.modelInputFrames; frame++) {
+                      chunk[frame][x][y] = imageArr[chunkIndices.startX + x][chunkIndices.startY + y][chunkIndices.startFrame + frame];
+                  }
+              }
+          }
+
+          return new Pair<>(chunk, resultIndices); // Return chunk and ResultIndices
+        }
+    }
+}

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/ChunkGenerator.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/ChunkGenerator.java
@@ -58,20 +58,10 @@ public class ChunkGenerator {
     }
 
     public float[][][] generateResultArray() {
-        System.out.println(imageDimX);
-        System.out.println(imageDimY);
-        System.out.println(imageDimFrames);
-        System.out.println(strideX);
-        System.out.println(strideY);
-        System.out.println(strideFrames);
-
         int resultDimX = (imageDimX - modelInputX) / strideX + 1;
         int resultDimY = (imageDimY - modelInputY) / strideY + 1;
         int resultDimFrames = (imageDimFrames - modelInputFrames) / strideFrames + 1;
-        
-        System.out.println(resultDimX);
-        System.out.println(resultDimY);
-        System.out.println(resultDimFrames);
+
         return new float[resultDimX][resultDimY][resultDimFrames];
     }
     

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/ChunkGenerator.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/ChunkGenerator.java
@@ -17,6 +17,7 @@ public class ChunkGenerator {
     private final int strideX;
     private final int strideY;
     private final int strideFrames;
+    private int totalChunks;
 
     public ChunkGenerator(int imageDimX, int imageDimY, int imageDimFrames,
                    int modelInputX, int modelInputY, int modelInputFrames,
@@ -31,6 +32,7 @@ public class ChunkGenerator {
         this.strideX = strideX;
         this.strideY = strideY;
         this.strideFrames = strideFrames;
+        this.totalChunks = 0;       // Calculated dynamically.
     }
 
     public List<ChunkIndices> generateChunkIndicesList() {
@@ -43,6 +45,7 @@ public class ChunkGenerator {
                     int endY = y + modelInputY;
                     int endFrame = frame + modelInputFrames;
                     indicesList.add(new ChunkIndices(x, endX, y, endY, frame, endFrame));
+                    ++this.totalChunks;
                 }
             }
         }
@@ -110,5 +113,9 @@ public class ChunkGenerator {
 
           return new Pair<>(chunk, resultIndices); // Return chunk and ResultIndices
         }
+    }
+
+    public int getTotalChunks() {
+        return this.totalChunks;
     }
 }

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/ChunkGenerator.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/ChunkGenerator.java
@@ -20,8 +20,8 @@ public class ChunkGenerator {
     private int totalChunks;
 
     public ChunkGenerator(int imageDimX, int imageDimY, int imageDimFrames,
-                   int modelInputX, int modelInputY, int modelInputFrames,
-                   int strideX, int strideY, int strideFrames) {
+            int modelInputX, int modelInputY, int modelInputFrames,
+            int strideX, int strideY, int strideFrames) {
 
         this.imageDimX = imageDimX;
         this.imageDimY = imageDimY;
@@ -32,7 +32,7 @@ public class ChunkGenerator {
         this.strideX = strideX;
         this.strideY = strideY;
         this.strideFrames = strideFrames;
-        this.totalChunks = 0;       // Calculated dynamically.
+        this.totalChunks = 0; // Calculated dynamically.
     }
 
     public List<ChunkIndices> generateChunkIndicesList() {
@@ -52,7 +52,6 @@ public class ChunkGenerator {
         return indicesList;
     }
 
-
     public ResultIndices mapChunkIndicesToResultIndices(ChunkIndices chunkIndices) {
         int resultX = chunkIndices.startX / strideX;
         int resultY = chunkIndices.startY / strideY;
@@ -67,51 +66,50 @@ public class ChunkGenerator {
 
         return new float[resultDimX][resultDimY][resultDimFrames];
     }
-    
-    public Iterator<Pair<float[][][], ResultIndices>> getChunkIterator(float[][][] imageArr) {
-      return new ChunkIterator(imageArr, this.modelInputX, this.modelInputY, this.modelInputFrames);
+
+    public Iterator<Pair<ChunkIndices, ResultIndices>> getChunkIterator() {
+        return new ChunkIterator();
     }
 
-    private class ChunkIterator implements Iterator<Pair<float[][][], ResultIndices>> {
-      private final Iterator<ChunkIndices> indicesIterator;
-      private final float[][][] imageArr;
-      private final int modelInputX;
-      private final int modelInputY;
-      private final int modelInputFrames;
+    private class ChunkIterator implements Iterator<Pair<ChunkIndices, ResultIndices>> {
+        private final Iterator<ChunkIndices> indicesIterator;
+        // private final int modelInputX;
+        // private final int modelInputY;
+        // private final int modelInputFrames;
 
-      public ChunkIterator(float[][][] imageArr, int modelInputX, int modelInputY, int modelInputFrames) {
-          this.indicesIterator = generateChunkIndicesList().iterator();
-          this.imageArr = imageArr;
-          this.modelInputX = modelInputX;
-          this.modelInputY = modelInputY;
-          this.modelInputFrames = modelInputFrames;
-      }
+        public ChunkIterator() {
+            this.indicesIterator = generateChunkIndicesList().iterator();
+            // this.modelInputX = modelInputX;
+            // this.modelInputY = modelInputY;
+            // this.modelInputFrames = modelInputFrames;
+        }
 
-      @Override
-      public boolean hasNext() {
-          return indicesIterator.hasNext();
-      }
+        @Override
+        public boolean hasNext() {
+            return indicesIterator.hasNext();
+        }
 
-      @Override
-      public Pair<float[][][], ResultIndices> next() {
-          if (!hasNext()) {
-              throw new NoSuchElementException();
-          }
+        @Override
+        public Pair<ChunkIndices, ResultIndices> next() {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
 
-          ChunkIndices chunkIndices = indicesIterator.next();
-          ResultIndices resultIndices = mapChunkIndicesToResultIndices(chunkIndices);
+            ChunkIndices chunkIndices = indicesIterator.next();
+            ResultIndices resultIndices = mapChunkIndicesToResultIndices(chunkIndices);
 
-          // Extract the chunk
-          float[][][] chunk = new float[this.modelInputFrames][this.modelInputX][this.modelInputY];
-          for (int x = 0; x < this.modelInputX; x++) {
-              for (int y = 0; y < this.modelInputY; y++) {
-                  for (int frame = 0; frame < this.modelInputFrames; frame++) {
-                      chunk[frame][x][y] = imageArr[chunkIndices.startX + x][chunkIndices.startY + y][chunkIndices.startFrame + frame];
-                  }
-              }
-          }
+            // Extract the chunk
+            // float[][][] chunk = new float[this.modelInputFrames][this.modelInputX][this.modelInputY];
+            // for (int x = 0; x < this.modelInputX; x++) {
+            //     for (int y = 0; y < this.modelInputY; y++) {
+            //         for (int frame = 0; frame < this.modelInputFrames; frame++) {
+            //             chunk[frame][x][y] = imageArr[chunkIndices.startX + x][chunkIndices.startY
+            //                     + y][chunkIndices.startFrame + frame];
+            //         }
+            //     }
+            // }
 
-          return new Pair<>(chunk, resultIndices); // Return chunk and ResultIndices
+            return new Pair<>(chunkIndices, resultIndices); // Return chunk and ResultIndices
         }
     }
 

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/ChunkIndices.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/ChunkIndices.java
@@ -1,0 +1,19 @@
+package fiji.plugin.imaging_fcs.imfcs.model.onnx;
+
+class ChunkIndices {
+    int startX;
+    int endX;
+    int startY;
+    int endY;
+    int startFrame;
+    int endFrame;
+
+    public ChunkIndices(int startX, int endX, int startY, int endY, int startFrame, int endFrame) {
+        this.startX = startX;
+        this.endX = endX;
+        this.startY = startY;
+        this.endY = endY;
+        this.startFrame = startFrame;
+        this.endFrame = endFrame;
+    }
+}

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/DeepLearningProcessor.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/DeepLearningProcessor.java
@@ -200,4 +200,8 @@ public class DeepLearningProcessor {
     public InputMetadata getInputMetadata() {
         return this.onnxModel.getInputMetadata();
     }
+    
+    public OnnxPredictor getOnnxPredictor() {
+        return this.onnxModel;
+    }
 }

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/DeepLearningProcessor.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/DeepLearningProcessor.java
@@ -5,6 +5,7 @@ import ai.onnxruntime.OrtException;
 import ij.IJ;
 import ij.ImagePlus;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -37,7 +38,7 @@ public class DeepLearningProcessor {
         // Initialize the array store.
         this.imageDimX = img.getWidth();
         this.imageDimY = img.getHeight();
-        this.imageDimFrames = img.getNSlices();
+        this.imageDimFrames = img.getImageStackSize();
 
         this.imageArr = new float[this.imageDimX][this.imageDimY][this.imageDimFrames];
     }

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/DeepLearningProcessor.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/DeepLearningProcessor.java
@@ -1,0 +1,188 @@
+package fiji.plugin.imaging_fcs.imfcs.model.onnx;
+
+import ai.onnxruntime.OnnxTensor;
+import ai.onnxruntime.OrtException;
+import ij.ImagePlus;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.List;
+import java.nio.FloatBuffer;
+
+import fiji.plugin.imaging_fcs.imfcs.model.BleachCorrectionModel;
+import fiji.plugin.imaging_fcs.imfcs.utils.Pair;
+
+public class DeepLearningProcessor {
+    private final BleachCorrectionModel bleachCorrectionModel;
+    private ImagePlus loadedImage;
+    private int imageDimX;
+    private int imageDimY;
+    private int imageDimFrames;
+    private float[][][] imageArr;
+    private OnnxPredictor onnxModel;
+    private ChunkGenerator chunker;
+    private boolean useGpu;
+
+    public DeepLearningProcessor(BleachCorrectionModel bleachCorrectionModel, boolean useGpu) {
+        this.useGpu = useGpu;
+        this.bleachCorrectionModel = bleachCorrectionModel;
+    }
+
+    // Initializes the arrays based on a loaded image.
+    public void loadImage(ImagePlus img) {
+        this.loadedImage = img;
+
+        // Initialize the array store.
+        this.imageDimX = img.getWidth();
+        this.imageDimY = img.getHeight();
+        this.imageDimFrames = img.getNSlices();
+
+        this.imageArr = new float[this.imageDimX][this.imageDimY][this.imageDimFrames];
+    }
+
+    // Prepare the pixels by extracting values and doing bleach correction if requested.
+    private void preparePixels(int initialFrame, int finalFrame) {
+        System.out.println(initialFrame);
+        System.out.println(finalFrame);
+        for (int x = 0; x < this.imageDimX; x++) {
+            for (int y = 0; y < this.imageDimY; y++) {
+                double[] intensityData = bleachCorrectionModel.getIntensity(this.loadedImage, x, y, 1, initialFrame, finalFrame);
+
+                // Iterate through the frames within the specified range
+                for (int t = initialFrame; t < finalFrame; t++) {
+                    // Calculate the correct index into intensityData.
+                    int intensityIndex = t - initialFrame;
+
+                    // Store the bleach-corrected intensity.
+                    //  - Cast the double to a float.
+                    this.imageArr[x][y][t] = (float) intensityData[intensityIndex];
+                }
+            }
+        }
+    }
+
+    public void loadOnnxModel(String modelPath) throws OrtException {
+        this.onnxModel = new OnnxPredictor(modelPath, this.useGpu);
+    }
+
+
+ /**
+     * Processes the loaded image by iterating through chunks, running inference,
+     * and aggregating results for each named output of the ONNX model.
+     *
+     * @param modelInputX    Model input X dimension.
+     * @param modelInputY    Model input Y dimension.
+     * @param modelInputFrames Model input frame dimension.
+     * @param strideX        Stride in X dimension.
+     * @param strideY        Stride in Y dimension.
+     * @param strideFrames   Stride in frame dimension.
+     * @param initialFrame   Initial frame to process.
+     * @param finalFrame     Final frame to process.
+     * @return A Map where keys are the ONNX model output names and values are
+     *         3D float arrays (float[][][]) containing the aggregated results for that output.
+     * @throws OrtException If there is an error during ONNX processing.
+     */
+    public Map<String, float[][][]> processImage(int strideX, int strideY, int strideFrames,
+                                                 int initialFrame, int finalFrame) throws OrtException {
+        // Extract model input properties from the metadata.
+        InputMetadata inputMetadata = onnxModel.getInputMetadata();
+        int modelInputX = (int) inputMetadata.modelInputX;
+        int modelInputY = (int) inputMetadata.modelInputY;
+        int modelInputFrames = (int) inputMetadata.modelInputFrames;
+
+        // Prepare pixels (bleach correction, etc.)
+        preparePixels(initialFrame, finalFrame);
+
+        // Create the ChunkGenerator
+        this.chunker = new ChunkGenerator(imageDimX, imageDimY, imageDimFrames,
+                modelInputX, modelInputY, modelInputFrames,
+                strideX, strideY, strideFrames);
+
+        // Initialize the map to hold result arrays for each output name
+        Map<String, float[][][]> resultsMap = new HashMap<>();
+        List<String> outputNames = onnxModel.getOutputNames(); // Get expected output names from the model
+        for (String name : outputNames) {
+            // Create a result array structure matching the chunking scheme for each output
+            resultsMap.put(name, chunker.generateResultArray());
+        }
+
+        // Get the chunk iterator
+        Iterator<Pair<float[][][], ResultIndices>> chunkIterator = chunker.getChunkIterator(imageArr);
+
+        // Process each chunk
+        while (chunkIterator.hasNext()) {
+            Pair<float[][][], ResultIndices> pair = chunkIterator.next();
+            float[][][] chunk = pair.getLeft();
+            ResultIndices resultIndices = pair.getRight();
+
+            // Add channel dimension for ONNX model (Batch=1, Channel=1)
+            // The shape should be [Batch, Channel, Frames, X, Y]
+            // chunk dimensions are [Frames][X][Y]
+            // Shape for createTensor should match model input spec: [1, 1, modelInputFrames, modelInputX, modelInputY]
+            long[] inputShape = new long[]{1, 1, modelInputFrames, modelInputX, modelInputY};
+
+            // Prepare input tensor within a try-with-resources block for auto-closing
+            try (OnnxTensor onnxTensor = OnnxTensor.createTensor(
+                    onnxModel.getEnvironment(),
+                    FloatBuffer.wrap(flattenChunk(chunk)), // Use a specific flatten for the chunk
+                    inputShape))
+            {
+                Map<String, OnnxTensor> inputMap = new HashMap<>();
+                inputMap.put(onnxModel.getInputNames().get(0), onnxTensor); // Assuming only one input
+
+                // Run inference - This now returns Map<String, Float>
+                // ONNX resources related to output are managed within runInference
+                Map<String, Float> chunkOutputData = onnxModel.runInference(inputMap);
+
+                // Process results and fill in the appropriate result array in the map
+                for (Map.Entry<String, Float> entry : chunkOutputData.entrySet()) {
+                    String outputName = entry.getKey();
+                    float predictionValue = entry.getValue();
+
+                    // Get the correct result array from the map based on the output name
+                    float[][][] targetArray = resultsMap.get(outputName);
+
+                    // Defensive check (should not happen if initialized correctly based on model metadata)
+                    if (targetArray == null) {
+                         System.err.println("Warning: No result array found in resultsMap for output name: " + outputName + ". Skipping.");
+                         continue; // Skip this output if structure wasn't pre-allocated
+                    }
+
+                    // Fill the specific result array at the calculated indices
+                    targetArray[resultIndices.resultX][resultIndices.resultY][resultIndices.resultFrame] = predictionValue;
+                }
+                // input 'onnxTensor' is closed automatically by try-with-resources
+
+            } // End try-with-resources for input onnxTensor
+        } // End while loop over chunks
+
+        // Return the map containing all aggregated result arrays
+        return resultsMap;
+    }
+
+    // Helper function specifically to flatten a 3D float chunk [Frames][X][Y]
+    // into the order expected by the FloatBuffer for shape [1, 1, Frames, X, Y]
+    private static float[] flattenChunk(float[][][] chunk) {
+        int dimFrames = chunk.length;
+        int dimX = chunk[0].length;
+        int dimY = chunk[0][0].length;
+        float[] flattened = new float[dimFrames * dimX * dimY];
+        int index = 0;
+        // Order: Frames, X, Y (matches typical memory layout for this structure)
+        for (int f = 0; f < dimFrames; f++) {
+            for (int x = 0; x < dimX; x++) {
+                for (int y = 0; y < dimY; y++) {
+                    flattened[index++] = chunk[f][x][y];
+                }
+            }
+        }
+        return flattened;
+    }
+
+    // Close methods to prevent resource leaks
+    public void close() throws OrtException {
+      if (onnxModel != null)
+        onnxModel.close();
+    }
+}

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/DeepLearningProcessor.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/DeepLearningProcessor.java
@@ -2,6 +2,7 @@ package fiji.plugin.imaging_fcs.imfcs.model.onnx;
 
 import ai.onnxruntime.OnnxTensor;
 import ai.onnxruntime.OrtException;
+import ij.IJ;
 import ij.ImagePlus;
 
 import java.util.HashMap;
@@ -111,9 +112,13 @@ public class DeepLearningProcessor {
 
         // Get the chunk iterator
         Iterator<Pair<float[][][], ResultIndices>> chunkIterator = chunker.getChunkIterator(imageArr);
+        
+        int currentChunkInd = 0;
+        int totalChunks = chunker.getTotalChunks();
 
         // Process each chunk
         while (chunkIterator.hasNext()) {
+            ++currentChunkInd;
             Pair<float[][][], ResultIndices> pair = chunkIterator.next();
             float[][][] chunk = pair.getLeft();
             ResultIndices resultIndices = pair.getRight();
@@ -159,6 +164,8 @@ public class DeepLearningProcessor {
                 // input 'onnxTensor' is closed automatically by try-with-resources
 
             } // End try-with-resources for input onnxTensor
+            // Update ImageJ progress bar
+            IJ.showProgress((double) currentChunkInd / (double) totalChunks);
         } // End while loop over chunks
 
         // Return the map containing all aggregated result arrays

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/DeepLearningProcessor.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/DeepLearningProcessor.java
@@ -185,4 +185,11 @@ public class DeepLearningProcessor {
       if (onnxModel != null)
         onnxModel.close();
     }
+
+    public boolean isOnnxSessionStarted() {
+        if (onnxModel != null && onnxModel.getEnvironment() != null) {
+            return true;
+        }
+        return false;
+    }
 }

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/DeepLearningProcessor.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/DeepLearningProcessor.java
@@ -192,4 +192,8 @@ public class DeepLearningProcessor {
         }
         return false;
     }
+
+    public InputMetadata getInputMetadata() {
+        return this.onnxModel.getInputMetadata();
+    }
 }

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/DeepLearningProcessor.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/DeepLearningProcessor.java
@@ -129,7 +129,7 @@ public class DeepLearningProcessor {
                     inputShape))
             {
                 Map<String, OnnxTensor> inputMap = new HashMap<>();
-                inputMap.put(onnxModel.getInputNames().get(0), onnxTensor); // Assuming only one input
+                inputMap.put(onnxModel.getInputNames(), onnxTensor); // Assuming only one input
 
                 // Run inference - This now returns Map<String, Float>
                 // ONNX resources related to output are managed within runInference

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/DeepLearningProcessor.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/DeepLearningProcessor.java
@@ -5,6 +5,7 @@ import ai.onnxruntime.OrtException;
 import ij.IJ;
 import ij.ImagePlus;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -70,6 +71,37 @@ public class DeepLearningProcessor {
         this.onnxModel = new OnnxPredictor(modelPath, this.useGpu);
     }
 
+    public float[] extractAndStackBatch(List<Pair<ChunkIndices, ResultIndices>> batch, int frames, int width,
+            int height) {
+        int batchSize = batch.size();
+        // Default to 1 channel, might need to make this explicit if Dual Color used in
+        // future
+        int channels = 1;
+
+        // Here, flatten batch to match ONNX expected semantics
+        int totalSize = batchSize * channels * frames * width * height;
+        float[] flattenedBatch = new float[totalSize];
+
+        // Populate in loop
+        int index = 0;
+        for (Pair<ChunkIndices, ResultIndices> indexPair : batch) {
+            ChunkIndices chunkIndices = indexPair.getLeft();
+
+            int startX = chunkIndices.startX;
+            int startY = chunkIndices.startY;
+            int startFrame = chunkIndices.startFrame;
+
+            for (int f = 0; f < frames; f++) {
+                for (int x = 0; x < width; x++) {
+                    for (int y = 0; y < height; y++) {
+                        flattenedBatch[index++] = imageArr[startX + x][startY + y][startFrame + f];
+                    }
+                }
+            }
+        }
+        return flattenedBatch;
+    }
+
     /**
      * Processes the loaded image by iterating through chunks, running inference,
      * and aggregating results for each named output of the ONNX model.
@@ -88,7 +120,7 @@ public class DeepLearningProcessor {
      * @throws OrtException If there is an error during ONNX processing.
      */
     public Map<String, float[][][]> processImage(int strideX, int strideY, int strideFrames,
-            int initialFrame, int finalFrame) throws OrtException {
+            int initialFrame, int finalFrame, int batchSize) throws OrtException {
         // Extract model input properties from the metadata.
         InputMetadata inputMetadata = onnxModel.getInputMetadata();
         int modelInputX = (int) inputMetadata.modelInputX;
@@ -111,85 +143,79 @@ public class DeepLearningProcessor {
             resultsMap.put(name, chunker.generateResultArray());
         }
 
-        // Get the chunk iterator
-        Iterator<Pair<float[][][], ResultIndices>> chunkIterator = chunker.getChunkIterator(imageArr);
-        
+        // Initialize chunk index generator.
+        Iterator<Pair<ChunkIndices, ResultIndices>> indexIterator = chunker.getChunkIterator();
+
+        // Batch processing loop
         int currentChunkInd = 0;
         int totalChunks = chunker.getTotalChunks();
+        List<Pair<ChunkIndices, ResultIndices>> batch = new ArrayList<>(batchSize);
 
-        // Process each chunk
-        while (chunkIterator.hasNext()) {
-            ++currentChunkInd;
-            Pair<float[][][], ResultIndices> pair = chunkIterator.next();
-            float[][][] chunk = pair.getLeft();
-            ResultIndices resultIndices = pair.getRight();
+        while (indexIterator.hasNext() || !batch.isEmpty()) {
+            while (indexIterator.hasNext() && batch.size() < batchSize) {
+                batch.add(indexIterator.next());
+            }
 
-            // Add channel dimension for ONNX model (Batch=1, Channel=1)
-            // The shape should be [Batch, Channel, Frames, X, Y]
-            // chunk dimensions are [Frames][X][Y]
-            // Shape for createTensor should match model input spec: [1, 1,
-            // modelInputFrames, modelInputX, modelInputY]
-            long[] inputShape = new long[] { 1, 1, modelInputFrames, modelInputX, modelInputY };
+            if (batch.isEmpty()) {
+                break;
+            }
+
+            int actualBatchSize = batch.size();
+
+            long[] inputShape = new long[] {
+                actualBatchSize,
+                1, // channel dimension, assumed 1 for now, might change.
+                modelInputFrames,
+                modelInputX,
+                modelInputY,
+            };
+
+            float[] flattenedBatchData = extractAndStackBatch(batch, modelInputFrames, modelInputX, modelInputY);
+
+            Map<String, float[]> batchedOutputData;
 
             // Prepare input tensor within a try-with-resources block for auto-closing
             try (OnnxTensor onnxTensor = OnnxTensor.createTensor(
                     onnxModel.getEnvironment(),
-                    FloatBuffer.wrap(flattenChunk(chunk)), // Use a specific flatten for the chunk
+                    FloatBuffer.wrap(flattenedBatchData),
                     inputShape)) {
+                    
                 Map<String, OnnxTensor> inputMap = new HashMap<>();
-                inputMap.put(onnxModel.getInputNames(), onnxTensor); // Assuming only one input
+                inputMap.put(onnxModel.getInputNames(), onnxTensor);
+                
+                // ONNX inference.
+                batchedOutputData = onnxModel.runInferenceBatched(inputMap);
 
-                // Run inference - This now returns Map<String, Float>
-                // ONNX resources related to output are managed within runInference
-                Map<String, Float> chunkOutputData = onnxModel.runInference(inputMap);
+                // Result processing and populating result map
+                for (int i = 0; i < actualBatchSize; i++) {
+                    ResultIndices resultIndices = batch.get(i).getRight();
 
-                // Process results and fill in the appropriate result array in the map
-                for (Map.Entry<String, Float> entry : chunkOutputData.entrySet()) {
-                    String outputName = entry.getKey();
-                    float predictionValue = entry.getValue();
+                    for (Map.Entry<String, float[]> entry : batchedOutputData.entrySet()) {
+                        String outputName = entry.getKey();
+                        float[] predictionBatch = entry.getValue();
 
-                    // Get the correct result array from the map based on the output name
-                    float[][][] targetArray = resultsMap.get(outputName);
+                        float predictionValue = predictionBatch[i];
+                        float[][][] targetArray = resultsMap.get(outputName);
 
-                    // Defensive check (should not happen if initialized correctly based on model
-                    // metadata)
-                    if (targetArray == null) {
-                        System.err.println("Warning: No result array found in resultsMap for output name: " + outputName
-                                + ". Skipping.");
-                        continue; // Skip this output if structure wasn't pre-allocated
+                        if (targetArray == null) {
+                            continue;
+                        }
+
+                        targetArray[resultIndices.resultX][resultIndices.resultY][resultIndices.resultFrame] = predictionValue;
                     }
-
-                    // Fill the specific result array at the calculated indices
-                    targetArray[resultIndices.resultX][resultIndices.resultY][resultIndices.resultFrame] = predictionValue;
+                    currentChunkInd++;
                 }
-                // input 'onnxTensor' is closed automatically by try-with-resources
-
-            } // End try-with-resources for input onnxTensor
-            // Update ImageJ progress bar
+            } catch (OrtException e) {
+                IJ.error("ONNX Runtime Error during batch inference: " + e.getMessage());
+                throw e; 
+            }
+            
+            batch.clear();
             IJ.showProgress((double) currentChunkInd / (double) totalChunks);
-        } // End while loop over chunks
+        }
 
         // Return the map containing all aggregated result arrays
         return resultsMap;
-    }
-
-    // Helper function specifically to flatten a 3D float chunk [Frames][X][Y]
-    // into the order expected by the FloatBuffer for shape [1, 1, Frames, X, Y]
-    private static float[] flattenChunk(float[][][] chunk) {
-        int dimFrames = chunk.length;
-        int dimX = chunk[0].length;
-        int dimY = chunk[0][0].length;
-        float[] flattened = new float[dimFrames * dimX * dimY];
-        int index = 0;
-        // Order: Frames, X, Y (matches typical memory layout for this structure)
-        for (int f = 0; f < dimFrames; f++) {
-            for (int x = 0; x < dimX; x++) {
-                for (int y = 0; y < dimY; y++) {
-                    flattened[index++] = chunk[f][x][y];
-                }
-            }
-        }
-        return flattened;
     }
 
     // Close methods to prevent resource leaks
@@ -208,7 +234,7 @@ public class DeepLearningProcessor {
     public InputMetadata getInputMetadata() {
         return this.onnxModel.getInputMetadata();
     }
-    
+
     public OnnxPredictor getOnnxPredictor() {
         return this.onnxModel;
     }

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/InputMetadata.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/InputMetadata.java
@@ -1,6 +1,6 @@
 package fiji.plugin.imaging_fcs.imfcs.model.onnx;
 
-class InputMetadata {
+public class InputMetadata {
     long modelInputX;       // Corresponds to Width
     long modelInputY;       // Corresponds to Height
     long modelInputFrames;  // Corresponds to Frames
@@ -20,5 +20,17 @@ class InputMetadata {
                ", modelInputFrames=" + modelInputFrames +
                '}';
     }
+
+	public String getX() {
+        return String.valueOf(this.modelInputX);
+	}
+
+	public String getY() {
+        return String.valueOf(this.modelInputY);
+	}
+
+	public String getFrames() {
+        return String.valueOf(this.modelInputFrames);
+	}
 }
 

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/InputMetadata.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/InputMetadata.java
@@ -1,0 +1,24 @@
+package fiji.plugin.imaging_fcs.imfcs.model.onnx;
+
+class InputMetadata {
+    long modelInputX;       // Corresponds to Width
+    long modelInputY;       // Corresponds to Height
+    long modelInputFrames;  // Corresponds to Frames
+    
+    public InputMetadata(long modelInputX, long modelInputY, long modelInputFrames) {
+        this.modelInputX = modelInputX;
+        this.modelInputY = modelInputY;
+        this.modelInputFrames = modelInputFrames;
+    }
+
+    // Optional: Add a toString for easy printing/debugging
+    @Override
+    public String toString() {
+        return "InputMetadata{" +
+               "modelInputX=" + modelInputX +
+               ", modelInputY=" + modelInputY +
+               ", modelInputFrames=" + modelInputFrames +
+               '}';
+    }
+}
+

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/InputMetadata.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/InputMetadata.java
@@ -1,10 +1,10 @@
 package fiji.plugin.imaging_fcs.imfcs.model.onnx;
 
 public class InputMetadata {
-    long modelInputX;       // Corresponds to Width
-    long modelInputY;       // Corresponds to Height
-    long modelInputFrames;  // Corresponds to Frames
-    
+    long modelInputX; // Corresponds to Width
+    long modelInputY; // Corresponds to Height
+    long modelInputFrames; // Corresponds to Frames
+
     public InputMetadata(long modelInputX, long modelInputY, long modelInputFrames) {
         this.modelInputX = modelInputX;
         this.modelInputY = modelInputY;
@@ -15,22 +15,21 @@ public class InputMetadata {
     @Override
     public String toString() {
         return "InputMetadata{" +
-               "modelInputX=" + modelInputX +
-               ", modelInputY=" + modelInputY +
-               ", modelInputFrames=" + modelInputFrames +
-               '}';
+                "modelInputX=" + modelInputX +
+                ", modelInputY=" + modelInputY +
+                ", modelInputFrames=" + modelInputFrames +
+                '}';
     }
 
-	public String getX() {
+    public String getX() {
         return String.valueOf(this.modelInputX);
-	}
+    }
 
-	public String getY() {
+    public String getY() {
         return String.valueOf(this.modelInputY);
-	}
+    }
 
-	public String getFrames() {
+    public String getFrames() {
         return String.valueOf(this.modelInputFrames);
-	}
+    }
 }
-

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/OnnxBatchModel.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/OnnxBatchModel.java
@@ -1,0 +1,61 @@
+package fiji.plugin.imaging_fcs.imfcs.model.onnx;
+
+/**
+ * Model class to store configuration settings for advanced ONNX inference
+ * batching and prefetching.
+ */
+public class OnnxBatchModel {
+
+    // Default configuration values
+    private static final int DEFAULT_BATCH_SIZE = 1;
+    private static final int DEFAULT_PREFETCH_WORKERS = 0; // 0 or 1 usually implies synchronous/no prefetching
+    private static final boolean DEFAULT_ENABLE_BATCHING = false;
+
+    private int batchSize;
+    private int numPrefetchWorkers;
+    private boolean batchingEnabled;
+
+    public OnnxBatchModel() {
+        this.batchSize = DEFAULT_BATCH_SIZE;
+        this.numPrefetchWorkers = DEFAULT_PREFETCH_WORKERS;
+        this.batchingEnabled = DEFAULT_ENABLE_BATCHING;
+    }
+
+    public int getBatchSize() {
+        return batchSize;
+    }
+
+    public int getNumPrefetchWorkers() {
+        return numPrefetchWorkers;
+    }
+
+    public boolean isBatchingEnabled() {
+        return batchingEnabled;
+    }
+
+    public void setBatchSize(String batchSize) {
+        Integer batchSizeInt = Integer.parseInt(batchSize);
+        if (batchSizeInt < 1) {
+            throw new IllegalArgumentException("Batch size must be at least 1.");
+        }
+        this.batchSize = batchSizeInt;
+    }
+
+    public void setNumPrefetchWorkers(String numPrefetchWorkers) {
+        Integer numPrefetchWorkersInt = Integer.parseInt(numPrefetchWorkers);
+        if (numPrefetchWorkersInt < 0) {
+            throw new IllegalArgumentException("Number of prefetch workers cannot be negative.");
+        }
+        this.numPrefetchWorkers = numPrefetchWorkersInt;
+    }
+
+    public void setBatchingEnabled(boolean batchingEnabled) {
+        this.batchingEnabled = batchingEnabled;
+        // Optional: If batching is disabled, reset workers to 0/1 and batch size to 1
+        // to simplify the runInference decision logic.
+        if (!batchingEnabled) {
+            this.batchSize = DEFAULT_BATCH_SIZE;
+            this.numPrefetchWorkers = DEFAULT_PREFETCH_WORKERS;
+        }
+    }
+}

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/OnnxPredictor.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/OnnxPredictor.java
@@ -19,7 +19,6 @@ public class OnnxPredictor implements AutoCloseable {
 
     private final OrtEnvironment env;
     private OrtSession session;
-    private final List<String> inputNames;
     private InputMetadata inputMetadata;
     private final List<String> outputNames;
     private final Map<String, long[]> outputShapes;
@@ -43,7 +42,6 @@ public class OnnxPredictor implements AutoCloseable {
      */
     public OnnxPredictor(String modelPath, boolean useGpu) throws OrtException {
         this.env = OrtEnvironment.getEnvironment();
-        this.inputNames = new ArrayList<>();
         this.outputNames = new ArrayList<>();
         this.outputShapes = new HashMap<>();
 
@@ -96,7 +94,7 @@ public class OnnxPredictor implements AutoCloseable {
             TensorInfo info = (TensorInfo) entry.getValue().getInfo();
             // Check if this is the specific input we want metadata from
             if (name.equals(TARGET_INPUT_NAME)) {
-                 // Ensure the NodeInfo is actually TensorInfo
+                // Ensure the NodeInfo is actually TensorInfo
                 if (info instanceof TensorInfo) {
                     long[] shape = info.getShape();
 
@@ -134,8 +132,8 @@ public class OnnxPredictor implements AutoCloseable {
         return env;
     }
 
-    public List<String> getInputNames() {
-        return inputNames;
+    public String getInputNames() {
+        return TARGET_INPUT_NAME;
     }
 
     public InputMetadata getInputMetadata() {

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/OnnxPredictor.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/OnnxPredictor.java
@@ -1,0 +1,210 @@
+package fiji.plugin.imaging_fcs.imfcs.model.onnx;
+
+import ai.onnxruntime.NodeInfo;
+import ai.onnxruntime.OnnxTensor;
+import ai.onnxruntime.OrtEnvironment;
+import ai.onnxruntime.OrtException;
+import ai.onnxruntime.OrtSession;
+import ai.onnxruntime.OrtSession.SessionOptions;
+import ai.onnxruntime.TensorInfo;
+import ai.onnxruntime.OrtSession.SessionOptions.OptLevel;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class OnnxPredictor implements AutoCloseable {
+
+    private final OrtEnvironment env;
+    private OrtSession session;
+    private final List<String> inputNames;
+    private InputMetadata inputMetadata;
+    private final List<String> outputNames;
+    private final Map<String, long[]> outputShapes;
+
+    // Define the expected name of the input tensor containing the shape info
+    private static final String TARGET_INPUT_NAME = "input";
+    // Define the expected indices based on [BATCH, CHANNELS, FRAMES, WIDTH, HEIGHT]
+    private static final int FRAMES_INDEX = 2;
+    private static final int WIDTH_INDEX = 3;  // Assuming width is 3rd dim (index 3)
+    private static final int HEIGHT_INDEX = 4; // Assuming height is 4th dim (index 4)
+    private static final int EXPECTED_DIMS = 5; // Expected number of dimensions
+
+    /**
+     * Creates an ONNX predictor model, optionally configuring GPU execution,
+     * with graph optimizations DISABLED for maximum numerical reproducibility.
+     *
+     * @param modelPath The file path to the .onnx model.
+     * @param useGpu    If true, attempts to configure the session with the CUDA execution provider.
+     *                  If false, or if CUDA configuration fails, uses the CPU provider.
+     * @throws OrtException If the model file cannot be loaded or the session cannot be created.
+     */
+    public OnnxPredictor(String modelPath, boolean useGpu) throws OrtException {
+        this.env = OrtEnvironment.getEnvironment();
+        this.inputNames = new ArrayList<>();
+        this.outputNames = new ArrayList<>();
+        this.outputShapes = new HashMap<>();
+
+        // Use try-with-resources for SessionOptions to ensure it's closed automatically
+        try (SessionOptions options = new SessionOptions()) {
+
+            // --- DISABLE OPTIMIZATIONS ---
+            // Set the optimization level to NONE before configuring providers.
+            // This ensures no graph optimizations are applied, prioritizing
+            // numerical reproducibility over potential speed gains.
+            System.out.println("Setting ONNX Runtime Optimization Level to: NO_OPTIMIZATION");
+            options.setOptimizationLevel(OptLevel.NO_OPT);
+            // --- END DISABLE OPTIMIZATIONS ---
+
+            if (useGpu) {
+                System.out.println("Attempting to configure ONNX Runtime session for GPU (CUDA).");
+                try {
+                    // Add the CUDA execution provider (device 0 is typically the default GPU)
+                    options.addCUDA(0);
+                    System.out.println("CUDA Execution Provider added to session options.");
+                    // No need to set OptLevel again here, it's already set to NO_OPTIMIZATION
+                } catch (OrtException e) {
+                    // Handle failure to add CUDA provider
+                    System.err.println("WARNING: Failed to add CUDA Execution Provider. " +
+                                       "Ensure Nvidia drivers and CUDA toolkit are compatible and installed. " +
+                                       "Falling back to CPU. Error: " + e.getMessage());
+                    // The OptLevel is already set to NO_OPTIMIZATION for the CPU fallback
+                }
+            } else {
+                System.out.println("Configuring ONNX Runtime session for CPU.");
+                // OptLevel is already set to NO_OPTIMIZATION
+            }
+
+            // Create the session using the configured options
+            this.session = env.createSession(modelPath, options);
+        } // SessionOptions 'options' is automatically closed here
+
+        // Extract metadata (input/output names and shapes) - same as before
+        extractMetadata();
+    }
+
+    // Helper method to keep constructor cleaner
+    private void extractMetadata() throws OrtException {
+        if (this.session == null) {
+            throw new IllegalStateException("Session is not initialized.");
+        }
+        // Extract input metadata
+        for (Map.Entry<String, NodeInfo> entry : session.getInputInfo().entrySet()) {
+            String name = entry.getKey();
+            TensorInfo info = (TensorInfo) entry.getValue().getInfo();
+            // Check if this is the specific input we want metadata from
+            if (name.equals(TARGET_INPUT_NAME)) {
+                 // Ensure the NodeInfo is actually TensorInfo
+                if (info instanceof TensorInfo) {
+                    long[] shape = info.getShape();
+
+                    // Validate shape - Ensure it has enough dimensions
+                    if (shape.length == EXPECTED_DIMS) {
+                        // Populate the metadata object
+                        // Note the cast from long to int - potential overflow if dims > Integer.MAX_VALUE
+                        long modelInputFrames = shape[FRAMES_INDEX];
+                        long modelInputX = shape[WIDTH_INDEX];
+                        long modelInputY = shape[HEIGHT_INDEX];
+                        this.inputMetadata = new InputMetadata(modelInputX, modelInputY, modelInputFrames);
+                    } else {
+                        // Handle error: Shape does not have the expected number of dimensions
+                        throw new IllegalStateException(
+                            "Input tensor '" + TARGET_INPUT_NAME + "' has shape " + Arrays.toString(shape) +
+                            ", but expected " + EXPECTED_DIMS + " dimensions.");
+                    }
+                } else {
+                     // Handle error: The node with the target name is not a Tensor
+                     throw new IllegalStateException(
+                        "Input node '" + TARGET_INPUT_NAME + "' is not of type TensorInfo.");
+                }
+            }
+        }
+        // Extract output metadata
+        for (Map.Entry<String, NodeInfo> entry : session.getOutputInfo().entrySet()) {
+            String name = entry.getKey();
+            TensorInfo info = (TensorInfo) entry.getValue().getInfo();
+            outputNames.add(name);
+            outputShapes.put(name, info.getShape());
+        }
+    }
+
+    public OrtEnvironment getEnvironment() {
+        return env;
+    }
+
+    public List<String> getInputNames() {
+        return inputNames;
+    }
+
+    public InputMetadata getInputMetadata() {
+        return inputMetadata;
+    }
+
+    public List<String> getOutputNames() {
+        return outputNames;
+    }
+
+    public Map<String, long[]> getOutputShapes() {
+        return outputShapes;
+    }
+
+ /**
+     * Runs inference using the provided input tensor map.
+     * Extracts the first float value from each output tensor.
+     * Manages the lifecycle of the session result and output tensors internally.
+     *
+     * @param input Map where keys are input tensor names and values are the OnnxTensor inputs.
+     * @return A Map where keys are the output tensor names and values are the single float result extracted from each.
+     * @throws OrtException If there is an error during inference or tensor processing.
+     */
+    public Map<String, Float> runInference(Map<String, OnnxTensor> input) throws OrtException {
+        Map<String, Float> outputDataMap = new HashMap<>();
+
+        // Use try-with-resources for OrtSession.Result
+        // This ensures that 'results' and all the OnnxTensor objects
+        // it contains are closed automatically when the block exits.
+        try (OrtSession.Result results = session.run(input)) {
+
+            // Iterate through the known output names obtained during model loading
+            for (Map.Entry<String, NodeInfo> entry : session.getOutputInfo().entrySet()) {
+                String outputName = entry.getKey();
+
+                // Get the output tensor from the results.
+                // The .get() retrieves the OnnxValue (which is an OnnxTensor here).
+                // The cast is safe based on typical ONNX model outputs.
+                OnnxTensor tensor = (OnnxTensor) results.get(outputName).get(); // .get() unwraps the internal value
+
+                // Extract the float value.
+                // Assuming output tensors for this model are shape [1] (batch size 1)
+                // or that we only need the very first float value.
+                float value = tensor.getFloatBuffer().get(0);
+
+                // Store the extracted primitive float value in the map
+                outputDataMap.put(outputName, value);
+
+                // No need to manually close 'tensor' here -
+                // the try-with-resources on 'results' handles it.
+            }
+
+        } // 'results' and all contained tensors are closed here.
+
+        return outputDataMap;
+    }
+
+    @Override
+    public void close() throws OrtException {
+        if (session != null) {
+            session.close();
+        }
+    }
+
+    //Inner class to contain input shapes
+    public class InputShape {
+      public List<String> shape;
+      public String type;
+
+      public InputShape() {}
+    }
+}

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/OnnxPredictor.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/OnnxPredictor.java
@@ -212,6 +212,7 @@ public class OnnxPredictor implements AutoCloseable {
     public void close() throws OrtException {
         if (session != null) {
             session.close();
+            session = null;
         }
     }
 

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/OnnxPredictor.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/OnnxPredictor.java
@@ -9,6 +9,7 @@ import ai.onnxruntime.OrtSession.SessionOptions;
 import ai.onnxruntime.TensorInfo;
 import ai.onnxruntime.OrtSession.SessionOptions.OptLevel;
 
+import java.nio.FloatBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -204,6 +205,43 @@ public class OnnxPredictor implements AutoCloseable {
             }
 
         } // 'results' and all contained tensors are closed here.
+
+        return outputDataMap;
+    }
+
+    /**
+     * Runs inference using a batched input tensor map (Batch size B > 0).
+     * Extracts the entire flattened output array for each output tensor.
+     * Manages the lifecycle of the session result and output tensors internally.
+     *
+     * @param input Map where keys are input tensor names and values are the
+     *              OnnxTensor inputs.
+     * @return A Map where keys are the output tensor names and values are the
+     *         flattened float array containing B predictions.
+     * @throws OrtException If there is an error during inference or tensor
+     *                      processing.
+     */
+    public Map<String, float[]> runInferenceBatched(Map<String, OnnxTensor> input) throws OrtException {
+        Map<String, float[]> outputDataMap = new HashMap<>();
+
+        // Use try-with-resources for OrtSession.Result to ensure automatic cleanup
+        try (OrtSession.Result results = session.run(input)) {
+
+            // Iterate through the known output names
+            for (Map.Entry<String, NodeInfo> entry : session.getOutputInfo().entrySet()) {
+                String outputName = entry.getKey();
+
+                OnnxTensor tensor = (OnnxTensor) results.get(outputName).get(); 
+                FloatBuffer floatBuffer = tensor.getFloatBuffer();
+                
+                // Determine the total size of the output data (B * K)
+                int bufferSize = floatBuffer.remaining();
+                float[] predictionArray = new float[bufferSize];
+                
+                floatBuffer.get(predictionArray);
+                outputDataMap.put(outputName, predictionArray);
+            }
+        }
 
         return outputDataMap;
     }

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/OnnxRuntimeStatus.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/OnnxRuntimeStatus.java
@@ -1,0 +1,35 @@
+package fiji.plugin.imaging_fcs.imfcs.model.onnx;
+
+/**
+ * Represents the different operational states of the ONNX Runtime environment.
+ */
+public enum OnnxRuntimeStatus {
+
+    NO_MODEL_LOADED("No Model Loaded"),           // Initial state
+    MODEL_SELECTED("Model Selected, Initializing..."), // File chosen, setup pending
+    READY("Ready for Inference"),           // ONNX Session created and ready
+    PROCESSING("Processing Inference..."),        // Actively running the model
+    ERROR_LOADING("Error Loading Model"),       // State if model loading/parsing failed
+    ERROR_PROCESSING("Error During Processing");  // State if inference failed
+
+    private final String displayLabel;
+
+    OnnxRuntimeStatus(String label) {
+        this.displayLabel = label;
+    }
+
+    /**
+     * Gets the user-friendly label associated with this status.
+     * @return The display label string.
+     */
+    public String getDisplayLabel() {
+        return displayLabel;
+    }
+
+    // Optional: Override toString() if you want System.out.println(status)
+    // to show the label directly, though getDisplayLabel() is more explicit.
+    @Override
+    public String toString() {
+        return displayLabel;
+    }
+}

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/ResultIndices.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/model/onnx/ResultIndices.java
@@ -1,0 +1,13 @@
+package fiji.plugin.imaging_fcs.imfcs.model.onnx;
+
+class ResultIndices {
+    int resultX;
+    int resultY;
+    int resultFrame;
+
+    public ResultIndices(int resultX, int resultY, int resultFrame) {
+        this.resultX = resultX;
+        this.resultY = resultY;
+        this.resultFrame = resultFrame;
+    }
+}

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/view/MainPanelView.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/view/MainPanelView.java
@@ -59,7 +59,7 @@ public final class MainPanelView extends BaseView {
             btnParamVideo, btnOptions, btnAve, btnParaCor, btnPSF, btnAll, btnROI, btnMore, btnCancel, btnBringToFront,
             btnNB;
     private JToggleButton tbExpSettings, tbFit, tbOverlap, tbBackground, tbFiltering, tbBleachCorStride, tbDL, tbSim,
-            tbMSD;
+            tbMSD, tbOnnxInference;
 
     // Extended panel for additional features
     private JPanel extendedPanel;
@@ -266,6 +266,8 @@ public final class MainPanelView extends BaseView {
         // set the button MSD based on the settings value
         tbMSD = createOnOffToggleButton("MSD", settings.isMSD(),
                 "Switches Mean Square Displacement calculation and " + "plot on/off.", null, controller.tbMSDPressed());
+
+        tbOnnxInference = createJToggleButton("ONNX Inference", "Show window for ONNX Model Inference", null, controller.tbOnnxInferencePressed());
     }
 
     /**
@@ -398,6 +400,9 @@ public final class MainPanelView extends BaseView {
         addRow(extendedPanel, btnPSF, tbDL, tbMSD, tbSim);
         addRow(extendedPanel, btnBringToFront);
         addRow(extendedPanel, btnCancel);
+
+        // ONNX Model section
+        addRow(extendedPanel, createJLabel("ONNX MODELS", "", BOLD_FONT), tbOnnxInference);
     }
 
     /**

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/view/OnnxBatchView.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/view/OnnxBatchView.java
@@ -73,7 +73,7 @@ public final class OnnxBatchView extends BaseView {
         // tfStrideX = createTextField("1", "Stride in X dimension (pixels)",
         // createFocusListener(model::setStrideX));
         // Batch Size
-        tfBatchSize = createTextField("1", "Maximum number of input windows to process simultaneously in a batch.",
+        tfBatchSize = createTextField("64", "Maximum number of input windows to process simultaneously in a batch.",
                 createFocusListener(model::setBatchSize));
 
         // Prefetch Workers (Optional setting for async loading)
@@ -159,7 +159,8 @@ public final class OnnxBatchView extends BaseView {
 
     public void setInputsEnabled(boolean enabled) {
         tfBatchSize.setEnabled(enabled);
-        tfPrefetchWorkers.setEnabled(enabled);
+        // For now, since prefetching is not implemented, disable this.
+        // tfPrefetchWorkers.setEnabled(enabled);
     }
 
     public boolean getBatchEnabledStatus() {

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/view/OnnxBatchView.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/view/OnnxBatchView.java
@@ -1,0 +1,168 @@
+package fiji.plugin.imaging_fcs.imfcs.view;
+
+import fiji.plugin.imaging_fcs.imfcs.constants.Constants;
+import fiji.plugin.imaging_fcs.imfcs.controller.OnnxBatchController;
+import fiji.plugin.imaging_fcs.imfcs.model.onnx.OnnxBatchModel;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ItemListener;
+
+import static fiji.plugin.imaging_fcs.imfcs.view.TextFieldFactory.createTextField;
+import static fiji.plugin.imaging_fcs.imfcs.view.UIUtils.createJLabel;
+import static fiji.plugin.imaging_fcs.imfcs.view.TextFieldFactory.setText;
+import static fiji.plugin.imaging_fcs.imfcs.controller.FieldListenerFactory.createFocusListener;
+
+/**
+ * Provides the user interface for configuring advanced ONNX batching
+ * parameters,
+ * such as maximum batch size and pre-fetch settings.
+ */
+public final class OnnxBatchView extends BaseView {
+
+    // --- Constants for Layout and Appearance ---
+    private static final GridLayout VIEW_LAYOUT = new GridLayout(5, 2, 5, 5); // Simple layout for settings
+    private static final Point VIEW_LOCATION = new Point(Constants.MAIN_PANEL_POS.x + 500,
+            Constants.MAIN_PANEL_POS.y + 10);
+    private static final Dimension VIEW_DIMENSION = new Dimension(350, 200);
+
+    private final OnnxBatchModel model;
+    private final OnnxBatchController controller;
+
+    // --- UI Component Fields ---
+    private JTextField tfBatchSize;
+    private JCheckBox cbEnableBatching;
+    private JTextField tfPrefetchWorkers;
+    private JLabel lblStatus;
+
+    /**
+     * Constructs the OnnxBatchView.
+     * (Model and Controller references omitted as per instruction to focus only on
+     * the view structure).
+     */
+    // If a controller/model were used:
+    // public OnnxBatchView(OnnxBatchController controller, OnnxBatchModel model) {
+    // ... }
+    public OnnxBatchView(OnnxBatchController controller, OnnxBatchModel model) {
+        super("ONNX Batch Settings");
+        this.model = model;
+        this.controller = controller;
+        initializeUI();
+    }
+
+    /**
+     * Sets up the basic window properties.
+     */
+    @Override
+    protected void configureWindow() {
+        super.configureWindow(); // Call parent setup
+
+        setLayout(VIEW_LAYOUT);
+        setLocation(VIEW_LOCATION);
+        setSize(VIEW_DIMENSION);
+        setResizable(false);
+
+        setVisible(false); // Keep it hidden until explicitly shown
+    }
+
+    /**
+     * Initialize UI components with default values and tooltips.
+     */
+    @Override
+    protected void initializeTextFields() {
+        // tfStrideX = createTextField("1", "Stride in X dimension (pixels)",
+        // createFocusListener(model::setStrideX));
+        // Batch Size
+        tfBatchSize = createTextField("1", "Maximum number of input windows to process simultaneously in a batch.",
+                createFocusListener(model::setBatchSize));
+
+        // Prefetch Workers (Optional setting for async loading)
+        tfPrefetchWorkers = createTextField("0",
+                "Number of background threads dedicated to prefetching data (0 = disabled).",
+                createFocusListener(model::setNumPrefetchWorkers));
+
+        // Checkbox
+        cbEnableBatching = new JCheckBox("Enable Batching");
+        cbEnableBatching
+                .setToolTipText("If enabled, inference will attempt to process multiple input windows per ONNX call.");
+
+        // Status Label
+        lblStatus = createJLabel("Status: Disabled", "Current status of the batching pipeline");
+    }
+
+    /**
+     * No specialized buttons needed for this simple view skeleton.
+     */
+    @Override
+    protected void initializeButtons() {
+        // No custom buttons currently defined for this view.
+    }
+
+    /**
+     * Adds the initialized UI components to the frame.
+     */
+    @Override
+    protected void addComponentsToFrame() {
+        // Row 1: Enable Checkbox
+        add(cbEnableBatching);
+        add(createJLabel("", ""));
+
+        // Row 2: Batch Size
+        add(createJLabel("Max Batch Size:", "Maximum number of inputs bundled per ONNX session call."));
+        add(tfBatchSize);
+
+        // Row 3: Prefetch Workers
+        add(createJLabel("Prefetch Workers:", "Number of threads to load data in background."));
+        add(tfPrefetchWorkers);
+
+        // Row 4: Spacer
+        add(createJLabel("", ""));
+        add(createJLabel("", ""));
+
+        // Row 5: Status Label
+        add(createJLabel("Current Status:", ""));
+        add(lblStatus);
+    }
+
+    // --- Public methods for Controller interaction (Skeletons) ---
+
+    public void updateStatus(String message) {
+        SwingUtilities.invokeLater(() -> {
+            lblStatus.setText(message);
+        });
+    }
+
+    // Example getter for controller
+    public int getBatchSize() {
+        try {
+            return Integer.parseInt(tfBatchSize.getText());
+        } catch (NumberFormatException e) {
+            return 1;
+        }
+    }
+
+    public void setBatchEnabledListener(ItemListener batchEnabledListener) {
+        this.cbEnableBatching.addItemListener(batchEnabledListener);
+    }
+
+    public void setBatchSizeText(String text) {
+        setText(tfBatchSize, text);
+    }
+
+    public void setPrefetchWorkersText(String text) {
+        setText(tfPrefetchWorkers, text);
+    }
+
+    public void setBatchEnabledStatus(boolean selected) {
+        this.cbEnableBatching.setSelected(selected);
+    }
+
+    public void setInputsEnabled(boolean enabled) {
+        tfBatchSize.setEnabled(enabled);
+        tfPrefetchWorkers.setEnabled(enabled);
+    }
+
+    public boolean getBatchEnabledStatus() {
+        return this.cbEnableBatching.isSelected();
+    }
+}

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/view/OnnxInferenceView.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/view/OnnxInferenceView.java
@@ -131,12 +131,15 @@ public final class OnnxInferenceView extends BaseView {
         cbUseGpu = new JCheckBox("Use GPU (if available)");
         cbUseGpu.setToolTipText("Attempt to use CUDA for inference if supported");
 
-        // Action Button
+        // Inference Button
         btnRunInference = createJButton("Run Inference", "Process the current image using the specified settings", null,
             (ActionListener) e -> {
                 controller.btnRunInferencePressed();
             });
         btnRunInference.setForeground(Color.RED);
+
+        // Start the inference button as disabled. Only enable explicitly once model is loaded.
+        this.disableRunInferenceButton();
 
         // Status Label
         lblStatus = createJLabel("Status: No Model Loaded", "Displays current operation status");

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/view/OnnxInferenceView.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/view/OnnxInferenceView.java
@@ -40,8 +40,6 @@ public final class OnnxInferenceView extends BaseView {
     private JTextField tfStrideX;
     private JTextField tfStrideY;
     private JTextField tfStrideFrames;
-    private JTextField tfInitialFrame;
-    private JTextField tfFinalFrame;
     private JCheckBox cbUseGpu;
     private JButton btnRunInference;
     private JLabel lblStatus; // To display messages like "Processing...", "Done", errors
@@ -105,10 +103,6 @@ public final class OnnxInferenceView extends BaseView {
         tfStrideX = createTextField("1", "Stride in X dimension (pixels)"); // Default based on example
         tfStrideY = createTextField("1", "Stride in Y dimension (pixels)"); // Default based on example
         tfStrideFrames = createTextField("2500", "Stride in Frames dimension"); // Default based on example
-
-        // Frame Range
-        tfInitialFrame = createTextField("1", "Initial frame to process (1-based index)"); // Default based on example (adjust if 0-based needed)
-        tfFinalFrame = createTextField("-1", "Final frame to process (-1 for end of stack)"); // Default based on example
 
         // GPU Option
         cbUseGpu = new JCheckBox("Use GPU (if available)");
@@ -235,8 +229,6 @@ public final class OnnxInferenceView extends BaseView {
              tfStrideX.setEnabled(!running);
              tfStrideY.setEnabled(!running);
              tfStrideFrames.setEnabled(!running);
-             tfInitialFrame.setEnabled(!running);
-             tfFinalFrame.setEnabled(!running);
              cbUseGpu.setEnabled(!running);
              btnRunInference.setEnabled(!running);
 

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/view/OnnxInferenceView.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/view/OnnxInferenceView.java
@@ -102,16 +102,6 @@ public final class OnnxInferenceView extends BaseView {
         // ONNX Model Path
         tfOnnxModelPath = createTextField("", "Path to the ONNX model file (.onnx)");
         tfOnnxModelPath.setEnabled(false); // Path often set via browser button
-        btnBrowseOnnx = createJButton("Load Model", "Select the ONNX model file", null, (ActionListener) e -> {
-            try {
-                controller.btnLoadPressed();
-            } catch (OrtException e1) {
-                IJ.log(e1.getStackTrace().toString());
-                IJ.error(e1.getMessage());
-            }
-        });
-        btnInitOnnx = createJButton("Init Model", "Start the ONNX environment for inference", null, 
-            (ActionListener) e -> controller.startOnnxSession());
 
         tfInputX = createTextField("", "Model expected input width (loaded from model)");
         tfInputX.setEditable(false); // Loaded from model metadata
@@ -131,6 +121,23 @@ public final class OnnxInferenceView extends BaseView {
         cbUseGpu = new JCheckBox("Use GPU (if available)");
         cbUseGpu.setToolTipText("Attempt to use CUDA for inference if supported");
 
+        // Status Label
+        lblStatus = createJLabel("Status: No Model Loaded", "Displays current operation status");
+    }
+
+    @Override
+    protected void initializeButtons() {
+        btnBrowseOnnx = createJButton("Load Model", "Select the ONNX model file", null, (ActionListener) e -> {
+            try {
+                controller.btnLoadPressed();
+            } catch (OrtException e1) {
+                IJ.log(e1.getStackTrace().toString());
+                IJ.error(e1.getMessage());
+            }
+        });
+        btnInitOnnx = createJButton("Init Model", "Start the ONNX environment for inference", null, 
+            (ActionListener) e -> controller.startOnnxSession());
+
         // Inference Button
         btnRunInference = createJButton("Run Inference", "Process the current image using the specified settings", null,
             (ActionListener) e -> {
@@ -141,8 +148,6 @@ public final class OnnxInferenceView extends BaseView {
         // Start the inference button as disabled. Only enable explicitly once model is loaded.
         this.disableRunInferenceButton();
 
-        // Status Label
-        lblStatus = createJLabel("Status: No Model Loaded", "Displays current operation status");
     }
 
     /**

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/view/OnnxInferenceView.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/view/OnnxInferenceView.java
@@ -1,12 +1,10 @@
 package fiji.plugin.imaging_fcs.imfcs.view;
 
 import fiji.plugin.imaging_fcs.imfcs.constants.Constants;
-import fiji.plugin.imaging_fcs.imfcs.controller.MainPanelController;
 
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionListener;
-import java.util.function.Function;
 
 import static fiji.plugin.imaging_fcs.imfcs.view.ButtonFactory.createJButton;
 import static fiji.plugin.imaging_fcs.imfcs.view.TextFieldFactory.createTextField;
@@ -87,8 +85,7 @@ public final class OnnxInferenceView extends BaseView {
         // ONNX Model Path
         tfOnnxModelPath = createTextField("", "Path to the ONNX model file (.onnx)");
         tfOnnxModelPath.setEnabled(false); // Path often set via browser button
-        btnBrowseOnnx = new JButton("Browse...");
-        btnBrowseOnnx.setToolTipText("Select the ONNX model file");
+        btnBrowseOnnx = createJButton("Load Model", "Select the ONNX model file", null, (ActionListener) e -> {});
 
         // Input Dimensions
         tfInputX = createTextField("", "Model input X dimension (pixels)");
@@ -102,7 +99,7 @@ public final class OnnxInferenceView extends BaseView {
         // Strides
         tfStrideX = createTextField("1", "Stride in X dimension (pixels)"); // Default based on example
         tfStrideY = createTextField("1", "Stride in Y dimension (pixels)"); // Default based on example
-        tfStrideFrames = createTextField("2500", "Stride in Frames dimension"); // Default based on example
+        tfStrideFrames = createTextField("2500", "Stride in Frames dimension"); // Default from original ImFCSNet model, but will autofill to the loaded model.
 
         // GPU Option
         cbUseGpu = new JCheckBox("Use GPU (if available)");

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/view/OnnxInferenceView.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/view/OnnxInferenceView.java
@@ -5,8 +5,10 @@ import fiji.plugin.imaging_fcs.imfcs.controller.MainPanelController;
 
 import javax.swing.*;
 import java.awt.*;
+import java.awt.event.ActionListener;
 import java.util.function.Function;
 
+import static fiji.plugin.imaging_fcs.imfcs.view.ButtonFactory.createJButton;
 import static fiji.plugin.imaging_fcs.imfcs.view.TextFieldFactory.createTextField;
 import static fiji.plugin.imaging_fcs.imfcs.view.UIUtils.createJLabel;
 
@@ -91,9 +93,13 @@ public final class OnnxInferenceView extends BaseView {
         btnBrowseOnnx.setToolTipText("Select the ONNX model file");
 
         // Input Dimensions
-        tfInputX = createTextField("3", "Model input X dimension (pixels)"); // Default based on example
-        tfInputY = createTextField("3", "Model input Y dimension (pixels)"); // Default based on example
-        tfInputFrames = createTextField("2500", "Model input Frames dimension"); // Default based on example
+        tfInputX = createTextField("", "Model input X dimension (pixels)");
+        tfInputY = createTextField("", "Model input Y dimension (pixels)");
+        tfInputFrames = createTextField("", "Model input Frames dimension");
+        // Disable these fields, as these are read from the model file.
+        tfInputX.setEnabled(false);
+        tfInputY.setEnabled(false);
+        tfInputFrames.setEnabled(false);
 
         // Strides
         tfStrideX = createTextField("1", "Stride in X dimension (pixels)"); // Default based on example
@@ -109,14 +115,11 @@ public final class OnnxInferenceView extends BaseView {
         cbUseGpu.setToolTipText("Attempt to use CUDA for inference if supported");
 
         // Action Button
-        btnRunInference = new JButton("Run Inference");
-        btnRunInference.setToolTipText("Process the current image using the specified settings");
+        btnRunInference = createJButton("Run Inference", "Process the current image using the specified settings", null, (ActionListener) e -> {});
+        btnRunInference.setForeground(Color.RED);
 
         // Status Label
         lblStatus = createJLabel("Status: Ready", "Displays current operation status");
-        // Allow label to change size if message is long
-        // lblStatus.setMinimumSize(new Dimension(100, 20));
-        // lblStatus.setPreferredSize(new Dimension(200, 20));
     }
 
     /**

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/view/OnnxInferenceView.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/view/OnnxInferenceView.java
@@ -43,6 +43,7 @@ public final class OnnxInferenceView extends BaseView {
     // --- UI Component Fields ---
     private JTextField tfOnnxModelPath;
     private JButton btnBrowseOnnx;
+    private JButton btnInitOnnx;
     private JTextField tfInputX;
     private JTextField tfInputY;
     private JTextField tfInputFrames;
@@ -109,6 +110,8 @@ public final class OnnxInferenceView extends BaseView {
                 IJ.error(e1.getMessage());
             }
         });
+        btnInitOnnx = createJButton("Init Model", "Start the ONNX environment for inference", null, 
+            (ActionListener) e -> controller.startOnnxSession());
 
         tfInputX = createTextField("", "Model expected input width (loaded from model)");
         tfInputX.setEditable(false); // Loaded from model metadata
@@ -149,8 +152,8 @@ public final class OnnxInferenceView extends BaseView {
         add(createJLabel("ONNX Model:", "Path to the ONNX model file (.onnx)"));
         add(tfOnnxModelPath);
         add(btnBrowseOnnx);
-        add(createJLabel("", "")); // Spacer
-
+        add(btnInitOnnx);
+        
         // Row 2: Input Dimensions (X, Y)
         add(createJLabel("Input X:", "Model input X dimension (pixels)"));
         add(tfInputX);
@@ -293,15 +296,15 @@ public final class OnnxInferenceView extends BaseView {
         return cbUseGpu.isSelected();
     }
 
-	public String getStrideX() {
+    public String getStrideX() {
         return this.tfStrideX.getText();
-	}
+    }
 
-	public String getStrideY() {
+    public String getStrideY() {
         return this.tfStrideY.getText();
-	}
+    }
 
-	public String getStrideFrames() {
+    public String getStrideFrames() {
         return this.tfStrideFrames.getText();
-	}
+    }
 }

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/view/OnnxInferenceView.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/view/OnnxInferenceView.java
@@ -1,6 +1,7 @@
 package fiji.plugin.imaging_fcs.imfcs.view;
 
 import fiji.plugin.imaging_fcs.imfcs.constants.Constants;
+import fiji.plugin.imaging_fcs.imfcs.model.OnnxInferenceModel;
 
 import javax.swing.*;
 import java.awt.*;
@@ -25,8 +26,8 @@ public final class OnnxInferenceView extends BaseView {
             new Point(Constants.MAIN_PANEL_POS.x, Constants.MAIN_PANEL_POS.y + Constants.MAIN_PANEL_DIM.height + 10);
     private static final Dimension VIEW_DIMENSION = new Dimension(480, 350); // Increased size
 
-    // --- Model and Controller References (Placeholders) ---
-    // private final OnnxInferenceModel model;
+    // --- Model and Controller References ---
+    private final OnnxInferenceModel model;
     // private final OnnxInferenceController controller;
 
     // --- UI Component Fields ---
@@ -52,11 +53,11 @@ public final class OnnxInferenceView extends BaseView {
      */
     public OnnxInferenceView(
         // OnnxInferenceController controller, 
-        // OnnxInferenceModel model
+        OnnxInferenceModel model
     ) {
         // Title for the window
         super("ONNX Inference Settings");
-        // this.model = model;
+        this.model = model;
         // this.controller = controller;
         initializeUI(); // This calls configureWindow, initializeTextFields, addComponentsToFrame
     }
@@ -110,7 +111,7 @@ public final class OnnxInferenceView extends BaseView {
         btnRunInference.setForeground(Color.RED);
 
         // Status Label
-        lblStatus = createJLabel("Status: Ready", "Displays current operation status");
+        lblStatus = createJLabel("Status: Not Ready", "Displays current operation status");
     }
 
     /**

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/view/OnnxInferenceView.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/view/OnnxInferenceView.java
@@ -11,6 +11,7 @@ import java.awt.event.ActionListener;
 import static fiji.plugin.imaging_fcs.imfcs.view.ButtonFactory.createJButton;
 import static fiji.plugin.imaging_fcs.imfcs.view.TextFieldFactory.createTextField;
 import static fiji.plugin.imaging_fcs.imfcs.view.UIUtils.createJLabel;
+import static fiji.plugin.imaging_fcs.imfcs.view.TextFieldFactory.setText;
 
 /**
  * Provides the user interface for configuring and running ONNX model inference
@@ -241,4 +242,14 @@ public final class OnnxInferenceView extends BaseView {
     // public JCheckBox getGpuCheckbox() { return cbUseGpu; }
     // public String getOnnxPath() { return tfOnnxModelPath.getText(); } // Controller might read directly on action
     // ... etc for other fields
+    //
+    public void updateModelPath(String modelPath) {
+        setText(tfOnnxModelPath, modelPath);
+    }
+
+    public void updateModelInputMetadata(int x, int y, int frames) {
+        setText(tfInputX, x);
+        setText(tfInputY, y);
+        setText(tfInputFrames, frames);
+    }
 }

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/view/OnnxInferenceView.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/view/OnnxInferenceView.java
@@ -131,7 +131,7 @@ public final class OnnxInferenceView extends BaseView {
         // Action Button
         btnRunInference = createJButton("Run Inference", "Process the current image using the specified settings", null,
             (ActionListener) e -> {
-                controller.infer();
+                controller.btnRunInferencePressed();
             });
         btnRunInference.setForeground(Color.RED);
 

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/view/OnnxInferenceView.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/view/OnnxInferenceView.java
@@ -13,6 +13,7 @@ import ai.onnxruntime.OrtException;
 import java.awt.*;
 import java.awt.event.ActionListener;
 
+import static fiji.plugin.imaging_fcs.imfcs.controller.FieldListenerFactory.createFocusListener;
 import static fiji.plugin.imaging_fcs.imfcs.view.ButtonFactory.createJButton;
 import static fiji.plugin.imaging_fcs.imfcs.view.TextFieldFactory.createTextField;
 import static fiji.plugin.imaging_fcs.imfcs.view.UIUtils.createJLabel;
@@ -20,7 +21,8 @@ import static fiji.plugin.imaging_fcs.imfcs.view.TextFieldFactory.setText;
 
 /**
  * Provides the user interface for configuring and running ONNX model inference
- * within the imaging FCS plugin. Users can specify the model path, input/stride dimensions,
+ * within the imaging FCS plugin. Users can specify the model path, input/stride
+ * dimensions,
  * frame ranges, and trigger the inference process.
  */
 public final class OnnxInferenceView extends BaseView {
@@ -28,9 +30,10 @@ public final class OnnxInferenceView extends BaseView {
     // --- Constants for Layout and Appearance (Adjust as needed) ---
     // Increased rows to accommodate more fields + button + status
     private static final GridLayout VIEW_LAYOUT = new GridLayout(9, 4, 5, 5); // Rows, Cols, Hgap, Vgap
-    // Adjust location and size based on where you want it relative to other plugin windows
-    private static final Point VIEW_LOCATION =
-            new Point(Constants.MAIN_PANEL_POS.x, Constants.MAIN_PANEL_POS.y + Constants.MAIN_PANEL_DIM.height + 10);
+    // Adjust location and size based on where you want it relative to other plugin
+    // windows
+    private static final Point VIEW_LOCATION = new Point(Constants.MAIN_PANEL_POS.x,
+            Constants.MAIN_PANEL_POS.y + Constants.MAIN_PANEL_DIM.height + 10);
     private static final Dimension VIEW_DIMENSION = new Dimension(480, 350); // Increased size
 
     // --- Model and Controller References ---
@@ -56,7 +59,6 @@ public final class OnnxInferenceView extends BaseView {
         PROCESSING,
     }
 
-
     /**
      * Constructs an OnnxInferenceView with references to its controller and model.
      * Initializes the UI components for the ONNX inference settings window.
@@ -65,9 +67,8 @@ public final class OnnxInferenceView extends BaseView {
      * @param model      The model holding ONNX inference parameters and state.
      */
     public OnnxInferenceView(
-        OnnxInferenceController controller, 
-        OnnxInferenceModel model
-    ) {
+            OnnxInferenceController controller,
+            OnnxInferenceModel model) {
         // Title for the window
         super("ONNX Inference Settings");
         this.model = model;
@@ -91,7 +92,8 @@ public final class OnnxInferenceView extends BaseView {
     }
 
     /**
-     * Initialize text fields, buttons, and checkbox with default values and tooltips.
+     * Initialize text fields, buttons, and checkbox with default values and
+     * tooltips.
      * No listeners are attached at this stage.
      */
     @Override
@@ -100,13 +102,13 @@ public final class OnnxInferenceView extends BaseView {
         tfOnnxModelPath = createTextField("", "Path to the ONNX model file (.onnx)");
         tfOnnxModelPath.setEnabled(false); // Path often set via browser button
         btnBrowseOnnx = createJButton("Load Model", "Select the ONNX model file", null, (ActionListener) e -> {
-			try {
-				controller.btnLoadPressed();
-			} catch (OrtException e1) {
+            try {
+                controller.btnLoadPressed();
+            } catch (OrtException e1) {
                 IJ.log(e1.getStackTrace().toString());
                 IJ.error(e1.getMessage());
-			}
-		});
+            }
+        });
 
         tfInputX = createTextField("", "Model expected input width (loaded from model)");
         tfInputX.setEditable(false); // Loaded from model metadata
@@ -116,16 +118,21 @@ public final class OnnxInferenceView extends BaseView {
         tfInputFrames.setEditable(false); // Loaded from model metadata
 
         // Strides
-        tfStrideX = createTextField("1", "Stride in X dimension (pixels)"); // Default based on example
-        tfStrideY = createTextField("1", "Stride in Y dimension (pixels)"); // Default based on example
-        tfStrideFrames = createTextField("2500", "Stride in Frames dimension"); // Default from original ImFCSNet model, but will autofill to the loaded model.
+        tfStrideX = createTextField("1", "Stride in X dimension (pixels)", createFocusListener(model::setStrideX));
+        tfStrideY = createTextField("1", "Stride in Y dimension (pixels)", createFocusListener(model::setStrideY));
+        // Default from original ImFCSNet model, but will autofill to the loaded model.
+        tfStrideFrames = createTextField("2500", "Stride in Frames dimension",
+                createFocusListener(model::setStrideFrames));
 
         // GPU Option
         cbUseGpu = new JCheckBox("Use GPU (if available)");
         cbUseGpu.setToolTipText("Attempt to use CUDA for inference if supported");
 
         // Action Button
-        btnRunInference = createJButton("Run Inference", "Process the current image using the specified settings", null, (ActionListener) e -> {});
+        btnRunInference = createJButton("Run Inference", "Process the current image using the specified settings", null,
+            (ActionListener) e -> {
+                controller.infer();
+            });
         btnRunInference.setForeground(Color.RED);
 
         // Status Label
@@ -157,9 +164,11 @@ public final class OnnxInferenceView extends BaseView {
         add(createJLabel("", "")); // Spacer
 
         // Row 4: Stride (X, Y)
-        add(createJLabel("Stride X:", "Stride in X dimension (pixels). Set equal to Model Input X for non-overlapping inference."));
+        add(createJLabel("Stride X:",
+                "Stride in X dimension (pixels). Set equal to Model Input X for non-overlapping inference."));
         add(tfStrideX);
-        add(createJLabel("Stride Y:", "Stride in Y dimension (pixels). Set equal to Model Input X for non-overlapping inference."));
+        add(createJLabel("Stride Y:",
+                "Stride in Y dimension (pixels). Set equal to Model Input X for non-overlapping inference."));
         add(tfStrideY);
 
         // Row 5: Stride (Frames)
@@ -206,7 +215,8 @@ public final class OnnxInferenceView extends BaseView {
         // add(createJLabel("", "")); // Spacer
         // --- Re-evaluate layout for status ---
         // Let's just put status label in col 2
-        // add(createJLabel("Status:", "Current operation status")); // Already added in prev row
+        // add(createJLabel("Status:", "Current operation status")); // Already added in
+        // prev row
         // add(lblStatus);
         // add(createJLabel("", "")); // Spacer
         // add(createJLabel("", "")); // Spacer
@@ -220,6 +230,7 @@ public final class OnnxInferenceView extends BaseView {
     /**
      * Updates the status message displayed to the user.
      * (To be called by the Controller).
+     * 
      * @param message The status message to display.
      */
     public void updateStatus(String message) {
@@ -232,25 +243,27 @@ public final class OnnxInferenceView extends BaseView {
     /**
      * Enables or disables UI components based on whether processing is running.
      * (To be called by the Controller).
-     * @param running True if processing is starting, false if it has finished or errored.
+     * 
+     * @param running True if processing is starting, false if it has finished or
+     *                errored.
      */
     public void setRunningState(boolean running) {
-         SwingUtilities.invokeLater(() -> {
-             // Disable input fields and buttons while running
-             tfOnnxModelPath.setEnabled(!running);
-             btnBrowseOnnx.setEnabled(!running);
-             tfInputX.setEnabled(!running);
-             tfInputY.setEnabled(!running);
-             tfInputFrames.setEnabled(!running);
-             tfStrideX.setEnabled(!running);
-             tfStrideY.setEnabled(!running);
-             tfStrideFrames.setEnabled(!running);
-             cbUseGpu.setEnabled(!running);
-             btnRunInference.setEnabled(!running);
+        SwingUtilities.invokeLater(() -> {
+            // Disable input fields and buttons while running
+            tfOnnxModelPath.setEnabled(!running);
+            btnBrowseOnnx.setEnabled(!running);
+            tfInputX.setEnabled(!running);
+            tfInputY.setEnabled(!running);
+            tfInputFrames.setEnabled(!running);
+            tfStrideX.setEnabled(!running);
+            tfStrideY.setEnabled(!running);
+            tfStrideFrames.setEnabled(!running);
+            cbUseGpu.setEnabled(!running);
+            btnRunInference.setEnabled(!running);
 
-             // Optionally change Run button text
-             btnRunInference.setText(running ? "Processing..." : "Run Inference");
-         });
+            // Optionally change Run button text
+            btnRunInference.setText(running ? "Processing..." : "Run Inference");
+        });
     }
 
     public void updateModelPath(String modelPath) {
@@ -279,4 +292,16 @@ public final class OnnxInferenceView extends BaseView {
     public boolean getUseGPU() {
         return cbUseGpu.isSelected();
     }
+
+	public String getStrideX() {
+        return this.tfStrideX.getText();
+	}
+
+	public String getStrideY() {
+        return this.tfStrideY.getText();
+	}
+
+	public String getStrideFrames() {
+        return this.tfStrideFrames.getText();
+	}
 }

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/view/OnnxInferenceView.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/view/OnnxInferenceView.java
@@ -21,7 +21,7 @@ public final class OnnxInferenceView extends BaseView {
 
     // --- Constants for Layout and Appearance (Adjust as needed) ---
     // Increased rows to accommodate more fields + button + status
-    private static final GridLayout VIEW_LAYOUT = new GridLayout(10, 4, 5, 5); // Rows, Cols, Hgap, Vgap
+    private static final GridLayout VIEW_LAYOUT = new GridLayout(9, 4, 5, 5); // Rows, Cols, Hgap, Vgap
     // Adjust location and size based on where you want it relative to other plugin windows
     private static final Point VIEW_LOCATION =
             new Point(Constants.MAIN_PANEL_POS.x, Constants.MAIN_PANEL_POS.y + Constants.MAIN_PANEL_DIM.height + 10);
@@ -158,31 +158,25 @@ public final class OnnxInferenceView extends BaseView {
         add(createJLabel("", "")); // Spacer
         add(createJLabel("", "")); // Spacer
 
-        // Row 6: Frame Range
-        add(createJLabel("Initial Frame:", "First frame to process (1-based index)"));
-        add(tfInitialFrame);
-        add(createJLabel("Final Frame:", "Last frame to process (-1 for end)"));
-        add(tfFinalFrame);
-
-        // Row 7: GPU Option
+        // Row 6: GPU Option
         add(cbUseGpu);
         add(createJLabel("", "")); // Spacer
         add(createJLabel("", "")); // Spacer
         add(createJLabel("", "")); // Spacer
 
-        // Row 8: Spacer Row (Optional)
+        // Row 7: Spacer Row (Optional)
         add(createJLabel("", ""));
         add(createJLabel("", ""));
         add(createJLabel("", ""));
         add(createJLabel("", ""));
 
-        // Row 9: Run Button
+        // Row 8: Run Button
         add(btnRunInference);
         add(createJLabel("", "")); // Spacer
         add(createJLabel("", "")); // Spacer
         add(createJLabel("", "")); // Spacer
 
-        // Row 10: Status Label
+        // Row 9: Status Label
         add(createJLabel("Status:", "Current operation status"));
         // Make status label span multiple columns for longer messages
         GridBagConstraints gbc = new GridBagConstraints();

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/view/OnnxInferenceView.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/view/OnnxInferenceView.java
@@ -1,6 +1,7 @@
 package fiji.plugin.imaging_fcs.imfcs.view;
 
 import fiji.plugin.imaging_fcs.imfcs.constants.Constants;
+import fiji.plugin.imaging_fcs.imfcs.controller.OnnxInferenceController;
 import fiji.plugin.imaging_fcs.imfcs.model.OnnxInferenceModel;
 
 import javax.swing.*;
@@ -28,7 +29,7 @@ public final class OnnxInferenceView extends BaseView {
 
     // --- Model and Controller References ---
     private final OnnxInferenceModel model;
-    // private final OnnxInferenceController controller;
+    private final OnnxInferenceController controller;
 
     // --- UI Component Fields ---
     private JTextField tfOnnxModelPath;
@@ -52,13 +53,13 @@ public final class OnnxInferenceView extends BaseView {
      * @param model      The model holding ONNX inference parameters and state.
      */
     public OnnxInferenceView(
-        // OnnxInferenceController controller, 
+        OnnxInferenceController controller, 
         OnnxInferenceModel model
     ) {
         // Title for the window
         super("ONNX Inference Settings");
         this.model = model;
-        // this.controller = controller;
+        this.controller = controller;
         initializeUI(); // This calls configureWindow, initializeTextFields, addComponentsToFrame
     }
 
@@ -86,16 +87,14 @@ public final class OnnxInferenceView extends BaseView {
         // ONNX Model Path
         tfOnnxModelPath = createTextField("", "Path to the ONNX model file (.onnx)");
         tfOnnxModelPath.setEnabled(false); // Path often set via browser button
-        btnBrowseOnnx = createJButton("Load Model", "Select the ONNX model file", null, (ActionListener) e -> {});
+        btnBrowseOnnx = createJButton("Load Model", "Select the ONNX model file", null, (ActionListener) e -> controller.btnLoadPressed());
 
-        // Input Dimensions
-        tfInputX = createTextField("", "Model input X dimension (pixels)");
-        tfInputY = createTextField("", "Model input Y dimension (pixels)");
-        tfInputFrames = createTextField("", "Model input Frames dimension");
-        // Disable these fields, as these are read from the model file.
-        tfInputX.setEnabled(false);
-        tfInputY.setEnabled(false);
-        tfInputFrames.setEnabled(false);
+        tfInputX = createTextField("", "Model expected input width (loaded from model)");
+        tfInputX.setEditable(false); // Loaded from model metadata
+        tfInputY = createTextField("", "Model expected input height (loaded from model)");
+        tfInputY.setEditable(false); // Loaded from model metadata
+        tfInputFrames = createTextField("", "Model expected input frames (loaded from model)");
+        tfInputFrames.setEditable(false); // Loaded from model metadata
 
         // Strides
         tfStrideX = createTextField("1", "Stride in X dimension (pixels)"); // Default based on example

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/view/OnnxInferenceView.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/view/OnnxInferenceView.java
@@ -1,0 +1,258 @@
+package fiji.plugin.imaging_fcs.imfcs.view;
+
+import fiji.plugin.imaging_fcs.imfcs.constants.Constants;
+import fiji.plugin.imaging_fcs.imfcs.controller.MainPanelController;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.function.Function;
+
+import static fiji.plugin.imaging_fcs.imfcs.view.TextFieldFactory.createTextField;
+import static fiji.plugin.imaging_fcs.imfcs.view.UIUtils.createJLabel;
+
+/**
+ * Provides the user interface for configuring and running ONNX model inference
+ * within the imaging FCS plugin. Users can specify the model path, input/stride dimensions,
+ * frame ranges, and trigger the inference process.
+ */
+public final class OnnxInferenceView extends BaseView {
+
+    // --- Constants for Layout and Appearance (Adjust as needed) ---
+    // Increased rows to accommodate more fields + button + status
+    private static final GridLayout VIEW_LAYOUT = new GridLayout(10, 4, 5, 5); // Rows, Cols, Hgap, Vgap
+    // Adjust location and size based on where you want it relative to other plugin windows
+    private static final Point VIEW_LOCATION =
+            new Point(Constants.MAIN_PANEL_POS.x, Constants.MAIN_PANEL_POS.y + Constants.MAIN_PANEL_DIM.height + 10);
+    private static final Dimension VIEW_DIMENSION = new Dimension(480, 350); // Increased size
+
+    // --- Model and Controller References (Placeholders) ---
+    // private final OnnxInferenceModel model;
+    // private final OnnxInferenceController controller;
+
+    // --- UI Component Fields ---
+    private JTextField tfOnnxModelPath;
+    private JButton btnBrowseOnnx;
+    private JTextField tfInputX;
+    private JTextField tfInputY;
+    private JTextField tfInputFrames;
+    private JTextField tfStrideX;
+    private JTextField tfStrideY;
+    private JTextField tfStrideFrames;
+    private JTextField tfInitialFrame;
+    private JTextField tfFinalFrame;
+    private JCheckBox cbUseGpu;
+    private JButton btnRunInference;
+    private JLabel lblStatus; // To display messages like "Processing...", "Done", errors
+
+
+    /**
+     * Constructs an OnnxInferenceView with references to its controller and model.
+     * Initializes the UI components for the ONNX inference settings window.
+     *
+     * @param controller The controller managing interactions for ONNX inference.
+     * @param model      The model holding ONNX inference parameters and state.
+     */
+    public OnnxInferenceView(
+        // OnnxInferenceController controller, 
+        // OnnxInferenceModel model
+    ) {
+        // Title for the window
+        super("ONNX Inference Settings");
+        // this.model = model;
+        // this.controller = controller;
+        initializeUI(); // This calls configureWindow, initializeTextFields, addComponentsToFrame
+    }
+
+    /**
+     * Sets up the basic window properties (layout, location, size).
+     */
+    @Override
+    protected void configureWindow() {
+        super.configureWindow(); // Call parent setup
+
+        setLayout(VIEW_LAYOUT);
+        setLocation(VIEW_LOCATION);
+        setSize(VIEW_DIMENSION);
+        // setResizable(false); // Optional: prevent resizing
+
+        setVisible(false); // Keep it hidden until explicitly shown
+    }
+
+    /**
+     * Initialize text fields, buttons, and checkbox with default values and tooltips.
+     * No listeners are attached at this stage.
+     */
+    @Override
+    protected void initializeTextFields() { // Renaming to initializeComponents might be better later
+        // ONNX Model Path
+        tfOnnxModelPath = createTextField("", "Path to the ONNX model file (.onnx)");
+        tfOnnxModelPath.setEnabled(false); // Path often set via browser button
+        btnBrowseOnnx = new JButton("Browse...");
+        btnBrowseOnnx.setToolTipText("Select the ONNX model file");
+
+        // Input Dimensions
+        tfInputX = createTextField("3", "Model input X dimension (pixels)"); // Default based on example
+        tfInputY = createTextField("3", "Model input Y dimension (pixels)"); // Default based on example
+        tfInputFrames = createTextField("2500", "Model input Frames dimension"); // Default based on example
+
+        // Strides
+        tfStrideX = createTextField("1", "Stride in X dimension (pixels)"); // Default based on example
+        tfStrideY = createTextField("1", "Stride in Y dimension (pixels)"); // Default based on example
+        tfStrideFrames = createTextField("2500", "Stride in Frames dimension"); // Default based on example
+
+        // Frame Range
+        tfInitialFrame = createTextField("1", "Initial frame to process (1-based index)"); // Default based on example (adjust if 0-based needed)
+        tfFinalFrame = createTextField("-1", "Final frame to process (-1 for end of stack)"); // Default based on example
+
+        // GPU Option
+        cbUseGpu = new JCheckBox("Use GPU (if available)");
+        cbUseGpu.setToolTipText("Attempt to use CUDA for inference if supported");
+
+        // Action Button
+        btnRunInference = new JButton("Run Inference");
+        btnRunInference.setToolTipText("Process the current image using the specified settings");
+
+        // Status Label
+        lblStatus = createJLabel("Status: Ready", "Displays current operation status");
+        // Allow label to change size if message is long
+        // lblStatus.setMinimumSize(new Dimension(100, 20));
+        // lblStatus.setPreferredSize(new Dimension(200, 20));
+    }
+
+    /**
+     * Adds the initialized UI components (labels, text fields, buttons, checkbox)
+     * to the view's frame according to the defined layout.
+     */
+    @Override
+    protected void addComponentsToFrame() {
+        // Row 1: ONNX Model Path
+        add(createJLabel("ONNX Model:", "Path to the ONNX model file (.onnx)"));
+        add(tfOnnxModelPath);
+        add(btnBrowseOnnx);
+        add(createJLabel("", "")); // Spacer
+
+        // Row 2: Input Dimensions (X, Y)
+        add(createJLabel("Input X:", "Model input X dimension (pixels)"));
+        add(tfInputX);
+        add(createJLabel("Input Y:", "Model input Y dimension (pixels)"));
+        add(tfInputY);
+
+        // Row 3: Input Dimensions (Frames)
+        add(createJLabel("Input Frames:", "Model input Frames dimension"));
+        add(tfInputFrames);
+        add(createJLabel("", "")); // Spacer
+        add(createJLabel("", "")); // Spacer
+
+        // Row 4: Stride (X, Y)
+        add(createJLabel("Stride X:", "Stride in X dimension (pixels)"));
+        add(tfStrideX);
+        add(createJLabel("Stride Y:", "Stride in Y dimension (pixels)"));
+        add(tfStrideY);
+
+        // Row 5: Stride (Frames)
+        add(createJLabel("Stride Frames:", "Stride in Frames dimension"));
+        add(tfStrideFrames);
+        add(createJLabel("", "")); // Spacer
+        add(createJLabel("", "")); // Spacer
+
+        // Row 6: Frame Range
+        add(createJLabel("Initial Frame:", "First frame to process (1-based index)"));
+        add(tfInitialFrame);
+        add(createJLabel("Final Frame:", "Last frame to process (-1 for end)"));
+        add(tfFinalFrame);
+
+        // Row 7: GPU Option
+        add(cbUseGpu);
+        add(createJLabel("", "")); // Spacer
+        add(createJLabel("", "")); // Spacer
+        add(createJLabel("", "")); // Spacer
+
+        // Row 8: Spacer Row (Optional)
+        add(createJLabel("", ""));
+        add(createJLabel("", ""));
+        add(createJLabel("", ""));
+        add(createJLabel("", ""));
+
+        // Row 9: Run Button
+        add(btnRunInference);
+        add(createJLabel("", "")); // Spacer
+        add(createJLabel("", "")); // Spacer
+        add(createJLabel("", "")); // Spacer
+
+        // Row 10: Status Label
+        add(createJLabel("Status:", "Current operation status"));
+        // Make status label span multiple columns for longer messages
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.gridwidth = 3; // Span 3 columns
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        add(lblStatus, gbc);
+        // Note: Adding components with GridBagConstraints directly might conflict
+        // if BaseView strictly uses the GridLayout set earlier.
+        // A simpler approach if GridBag isn't needed is just:
+        // add(lblStatus);
+        // add(createJLabel("", "")); // Spacer
+        // add(createJLabel("", "")); // Spacer
+        // Let's stick to the simpler grid layout adding for now:
+        // Remove the GBC code above and uncomment below:
+        // add(lblStatus);
+        // add(createJLabel("", "")); // Spacer
+        // add(createJLabel("", "")); // Spacer
+        // --- Re-evaluate layout for status ---
+        // Let's just put status label in col 2
+        // add(createJLabel("Status:", "Current operation status")); // Already added in prev row
+        // add(lblStatus);
+        // add(createJLabel("", "")); // Spacer
+        // add(createJLabel("", "")); // Spacer
+        // Let's try putting Status label and text on the last row:
+        add(lblStatus); // Occupies the last cell
+
+    }
+
+    // --- Placeholder methods for Controller interaction ---
+
+    /**
+     * Updates the status message displayed to the user.
+     * (To be called by the Controller).
+     * @param message The status message to display.
+     */
+    public void updateStatus(String message) {
+        // Ensure UI updates happen on the Event Dispatch Thread
+        SwingUtilities.invokeLater(() -> {
+            lblStatus.setText(message);
+        });
+    }
+
+    /**
+     * Enables or disables UI components based on whether processing is running.
+     * (To be called by the Controller).
+     * @param running True if processing is starting, false if it has finished or errored.
+     */
+    public void setRunningState(boolean running) {
+         SwingUtilities.invokeLater(() -> {
+             // Disable input fields and buttons while running
+             tfOnnxModelPath.setEnabled(!running);
+             btnBrowseOnnx.setEnabled(!running);
+             tfInputX.setEnabled(!running);
+             tfInputY.setEnabled(!running);
+             tfInputFrames.setEnabled(!running);
+             tfStrideX.setEnabled(!running);
+             tfStrideY.setEnabled(!running);
+             tfStrideFrames.setEnabled(!running);
+             tfInitialFrame.setEnabled(!running);
+             tfFinalFrame.setEnabled(!running);
+             cbUseGpu.setEnabled(!running);
+             btnRunInference.setEnabled(!running);
+
+             // Optionally change Run button text
+             btnRunInference.setText(running ? "Processing..." : "Run Inference");
+         });
+    }
+
+    // Add getter methods for components if the controller needs to directly access them
+    // (Though typically controller modifies model, and view updates from model changes)
+    // Example:
+    // public JButton getRunButton() { return btnRunInference; }
+    // public JCheckBox getGpuCheckbox() { return cbUseGpu; }
+    // public String getOnnxPath() { return tfOnnxModelPath.getText(); } // Controller might read directly on action
+    // ... etc for other fields
+}

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/view/OnnxInferenceView.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/view/OnnxInferenceView.java
@@ -307,4 +307,12 @@ public final class OnnxInferenceView extends BaseView {
     public String getStrideFrames() {
         return this.tfStrideFrames.getText();
     }
+
+    public void disableRunInferenceButton() {
+        this.btnRunInference.setEnabled(false);
+    }
+
+    public void enableRunInferenceButton() {
+        this.btnRunInference.setEnabled(true);
+    }
 }

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/view/OnnxInferenceView.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/view/OnnxInferenceView.java
@@ -139,8 +139,14 @@ public final class OnnxInferenceView extends BaseView {
             }
         });
         btnInitOnnx = createJButton("Init Model", "Start the ONNX environment for inference", null, 
-            (ActionListener) e -> controller.startOnnxSession());
-
+            (ActionListener) e ->  {
+            try {
+                controller.startOnnxSession();
+            } catch (OrtException e1) {
+                IJ.log(e1.getStackTrace().toString());
+                IJ.error(e1.getMessage());
+            }
+        });
         tbBatchSettings = createJToggleButton("Batch Settings", "Configure advanced batching parameters.", null,
                 controller.tbBatchSettingsPressed()); 
 

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/view/OnnxInferenceView.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/view/OnnxInferenceView.java
@@ -31,7 +31,7 @@ public final class OnnxInferenceView extends BaseView {
 
     // --- Constants for Layout and Appearance (Adjust as needed) ---
     // Increased rows to accommodate more fields + button + status
-    private static final GridLayout VIEW_LAYOUT = new GridLayout(9, 4, 5, 5); // Rows, Cols, Hgap, Vgap
+    // private static final GridLayout VIEW_LAYOUT = new GridLayout(9, 4, 5, 5); // Rows, Cols, Hgap, Vgap
     // Adjust location and size based on where you want it relative to other plugin
     // windows
     private static final Point VIEW_LOCATION = new Point(Constants.MAIN_PANEL_POS.x,
@@ -88,11 +88,11 @@ public final class OnnxInferenceView extends BaseView {
     protected void configureWindow() {
         super.configureWindow(); // Call parent setup
 
-        setLayout(VIEW_LAYOUT);
+        // setLayout(VIEW_LAYOUT);
+        setLayout(new GridBagLayout());
         setLocation(VIEW_LOCATION);
         setSize(VIEW_DIMENSION);
-        // setResizable(false); // Optional: prevent resizing
-
+        setResizable(true);
         setVisible(false); // Keep it hidden until explicitly shown
     }
 
@@ -165,12 +165,135 @@ public final class OnnxInferenceView extends BaseView {
 
     }
 
+    @Override
+    protected void addComponentsToFrame() {
+        // 1. Initialize GridBagConstraints
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.fill = GridBagConstraints.HORIZONTAL; // Components fill their cell width
+        gbc.insets = new Insets(5, 5, 5, 5); // Use the original hgap/vgap (5, 5) as padding
+        
+        // We want input fields to stretch more than labels or buttons
+        gbc.weightx = 1.0; // Default weight for components that span 1 column
+
+        int row = 0; // Start row counter
+
+        // --- Row 1: ONNX Model Path ---
+        
+        // Col 0: Label
+        gbc.gridx = 0;
+        gbc.gridy = row;
+        gbc.weightx = 0; // Labels typically don't stretch
+        gbc.gridwidth = 1;
+        add(createJLabel("ONNX Model:", "Path to the ONNX model file (.onnx)"), gbc);
+
+        // Col 1: Text Field (Give it more stretch capacity)
+        gbc.gridx = 1;
+        gbc.weightx = 1.0; 
+        add(tfOnnxModelPath, gbc);
+
+        // Col 2: Browse Button
+        gbc.gridx = 2;
+        gbc.weightx = 1.0;
+        add(btnBrowseOnnx, gbc);
+
+        // Col 3: Init Button
+        gbc.gridx = 3;
+        gbc.weightx = 1.0;
+        add(btnInitOnnx, gbc);
+
+        row++;
+        // Reset weightx for standard fields
+        gbc.weightx = 0.5; 
+
+        // --- Row 2: Input Dimensions (X, Y) ---
+        gbc.gridy = row;
+        gbc.gridx = 0; add(createJLabel("Input X:", "..."), gbc);
+        gbc.gridx = 1; add(tfInputX, gbc);
+        gbc.gridx = 2; add(createJLabel("Input Y:", "..."), gbc);
+        gbc.gridx = 3; add(tfInputY, gbc);
+
+        row++;
+
+        // --- Row 3: Input Dimensions (Frames) ---
+        gbc.gridy = row;
+        gbc.gridx = 0; add(createJLabel("Input Frames:", "..."), gbc);
+        gbc.gridx = 1; add(tfInputFrames, gbc);
+        gbc.gridx = 2; add(createJLabel("", ""), gbc); // Spacer
+        gbc.gridx = 3; add(createJLabel("", ""), gbc); // Spacer
+
+        row++;
+
+        // --- Row 4: Stride (X, Y) ---
+        gbc.gridy = row;
+        gbc.gridx = 0; add(createJLabel("Stride X:", "..."), gbc);
+        gbc.gridx = 1; add(tfStrideX, gbc);
+        gbc.gridx = 2; add(createJLabel("Stride Y:", "..."), gbc);
+        gbc.gridx = 3; add(tfStrideY, gbc);
+
+        row++;
+
+        // --- Row 5: Stride (Frames) ---
+        gbc.gridy = row;
+        gbc.gridx = 0; add(createJLabel("Stride Frames:", "..."), gbc);
+        gbc.gridx = 1; add(tfStrideFrames, gbc);
+        gbc.gridx = 2; add(createJLabel("", ""), gbc); // Spacer
+        gbc.gridx = 3; add(createJLabel("", ""), gbc); // Spacer
+
+        row++;
+
+        // --- Row 6: GPU Option / Batch Settings ---
+        gbc.gridy = row;
+        gbc.gridx = 0; add(cbUseGpu, gbc);
+        gbc.gridx = 1; add(tbBatchSettings, gbc);
+        gbc.gridx = 2; add(createJLabel("", ""), gbc);
+        gbc.gridx = 3; add(createJLabel("", ""), gbc);
+
+        row++;
+        
+        // --- Row 7: DEVICE LABEL (The Target) ---
+        // Make the label span all 4 columns.
+        gbc.gridy = row;
+        gbc.gridx = 0; // Start at column 0
+        gbc.gridwidth = 4; // Span four columns
+        gbc.weightx = 1.0; // Ensure it stretches fully across the row
+        
+        add(lblDevice, gbc);
+        
+        // Reset constraints for subsequent rows
+        gbc.gridwidth = 1;
+        gbc.weightx = 0.5; 
+        
+        row++;
+
+        // --- Row 8: Run Button ---
+        gbc.gridy = row;
+        gbc.gridx = 0; add(btnRunInference, gbc);
+        gbc.gridx = 1; add(createJLabel("", ""), gbc); // Spacer
+        gbc.gridx = 2; add(createJLabel("", ""), gbc); // Spacer
+        gbc.gridx = 3; add(createJLabel("", ""), gbc); // Spacer
+
+        row++;
+
+        // --- Row 9: Status Label ---
+        gbc.gridy = row;
+        
+        // Col 0: Label "Status:"
+        gbc.gridx = 0;
+        gbc.weightx = 0; // Don't let this label stretch
+        add(createJLabel("Status:", "Current operation status"), gbc);
+        
+        // Col 1-3: Status Message Field (Span 3 columns)
+        gbc.gridx = 1; 
+        gbc.gridwidth = 3; // Span the remaining 3 columns
+        gbc.weightx = 1.0; // Let the status message stretch fully
+        add(lblStatus, gbc);
+    }
+
     /**
      * Adds the initialized UI components (labels, text fields, buttons, checkbox)
      * to the view's frame according to the defined layout.
      */
-    @Override
-    protected void addComponentsToFrame() {
+    protected void _addComponentsToFrame() {
         // Row 1: ONNX Model Path
         add(createJLabel("ONNX Model:", "Path to the ONNX model file (.onnx)"));
         add(tfOnnxModelPath);

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/view/OnnxInferenceView.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/view/OnnxInferenceView.java
@@ -12,9 +12,11 @@ import ai.onnxruntime.OrtException;
 
 import java.awt.*;
 import java.awt.event.ActionListener;
+import java.awt.event.ItemListener;
 
 import static fiji.plugin.imaging_fcs.imfcs.controller.FieldListenerFactory.createFocusListener;
 import static fiji.plugin.imaging_fcs.imfcs.view.ButtonFactory.createJButton;
+import static fiji.plugin.imaging_fcs.imfcs.view.ButtonFactory.createJToggleButton;
 import static fiji.plugin.imaging_fcs.imfcs.view.TextFieldFactory.createTextField;
 import static fiji.plugin.imaging_fcs.imfcs.view.UIUtils.createJLabel;
 import static fiji.plugin.imaging_fcs.imfcs.view.TextFieldFactory.setText;
@@ -53,6 +55,7 @@ public final class OnnxInferenceView extends BaseView {
     private JCheckBox cbUseGpu;
     private JButton btnRunInference;
     private JLabel lblStatus;
+    private JToggleButton tbBatchSettings; 
 
     enum Status {
         NO_MODEL_LOADED,
@@ -138,6 +141,9 @@ public final class OnnxInferenceView extends BaseView {
         btnInitOnnx = createJButton("Init Model", "Start the ONNX environment for inference", null, 
             (ActionListener) e -> controller.startOnnxSession());
 
+        tbBatchSettings = createJToggleButton("Batch Settings", "Configure advanced batching parameters.", null,
+                controller.tbBatchSettingsPressed()); 
+
         // Inference Button
         btnRunInference = createJButton("Run Inference", "Process the current image using the specified settings", null,
             (ActionListener) e -> {
@@ -190,7 +196,7 @@ public final class OnnxInferenceView extends BaseView {
 
         // Row 6: GPU Option
         add(cbUseGpu);
-        add(createJLabel("", "")); // Spacer
+        add(tbBatchSettings);
         add(createJLabel("", "")); // Spacer
         add(createJLabel("", "")); // Spacer
 
@@ -263,6 +269,7 @@ public final class OnnxInferenceView extends BaseView {
             // Disable input fields and buttons while running
             tfOnnxModelPath.setEnabled(!running);
             btnBrowseOnnx.setEnabled(!running);
+            btnInitOnnx.setEnabled(!running);
             tfInputX.setEnabled(!running);
             tfInputY.setEnabled(!running);
             tfInputFrames.setEnabled(!running);

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/view/OnnxInferenceView.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/view/OnnxInferenceView.java
@@ -56,6 +56,7 @@ public final class OnnxInferenceView extends BaseView {
     private JButton btnRunInference;
     private JLabel lblStatus;
     private JToggleButton tbBatchSettings; 
+    private JLabel lblDevice;
 
     enum Status {
         NO_MODEL_LOADED,
@@ -123,9 +124,11 @@ public final class OnnxInferenceView extends BaseView {
         // GPU Option
         cbUseGpu = new JCheckBox("Use GPU (if available)");
         cbUseGpu.setToolTipText("Attempt to use CUDA for inference if supported");
+        cbUseGpu.addItemListener(controller.cbUseGpuToggled());
 
         // Status Label
         lblStatus = createJLabel("Status: No Model Loaded", "Displays current operation status");
+        lblDevice = createJLabel("Device: CPU", "Displays current ONNX device.");
     }
 
     @Override
@@ -203,11 +206,12 @@ public final class OnnxInferenceView extends BaseView {
         // Row 6: GPU Option
         add(cbUseGpu);
         add(tbBatchSettings);
-        add(createJLabel("", "")); // Spacer
-        add(createJLabel("", "")); // Spacer
+        add(createJLabel("", ""));
+        add(createJLabel("", ""));
 
         // Row 7: Spacer Row (Optional)
-        add(createJLabel("", ""));
+        add(lblDevice); // Here, replace spacer with the lblDevice.
+        // add(createJLabel("", ""));
         add(createJLabel("", ""));
         add(createJLabel("", ""));
         add(createJLabel("", ""));
@@ -225,41 +229,28 @@ public final class OnnxInferenceView extends BaseView {
         gbc.gridwidth = 3; // Span 3 columns
         gbc.fill = GridBagConstraints.HORIZONTAL;
         add(lblStatus, gbc);
-        // Note: Adding components with GridBagConstraints directly might conflict
-        // if BaseView strictly uses the GridLayout set earlier.
-        // A simpler approach if GridBag isn't needed is just:
-        // add(lblStatus);
-        // add(createJLabel("", "")); // Spacer
-        // add(createJLabel("", "")); // Spacer
-        // Let's stick to the simpler grid layout adding for now:
-        // Remove the GBC code above and uncomment below:
-        // add(lblStatus);
-        // add(createJLabel("", "")); // Spacer
-        // add(createJLabel("", "")); // Spacer
-        // --- Re-evaluate layout for status ---
-        // Let's just put status label in col 2
-        // add(createJLabel("Status:", "Current operation status")); // Already added in
-        // prev row
-        // add(lblStatus);
-        // add(createJLabel("", "")); // Spacer
-        // add(createJLabel("", "")); // Spacer
-        // Let's try putting Status label and text on the last row:
         add(lblStatus); // Occupies the last cell
-
     }
-
-    // --- Placeholder methods for Controller interaction ---
 
     /**
      * Updates the status message displayed to the user.
-     * (To be called by the Controller).
      * 
      * @param message The status message to display.
      */
     public void updateStatus(String message) {
-        // Ensure UI updates happen on the Event Dispatch Thread
         SwingUtilities.invokeLater(() -> {
             lblStatus.setText(message);
+        });
+    }
+
+    /**
+     * Updates the device displayed to the user.
+     * 
+     * @param message The status message to display.
+     */
+    public void updateDevice(String message) {
+        SwingUtilities.invokeLater(() -> {
+            lblDevice.setText(message);
         });
     }
 

--- a/src/main/java/fiji/plugin/imaging_fcs/imfcs/view/dialogs/BatchView.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/imfcs/view/dialogs/BatchView.java
@@ -53,6 +53,8 @@ public class BatchView extends GenericDialog {
         out.put("Save excel", getNextBoolean());
         out.put("Save plot windows", getNextBoolean());
 
+        out.put("ONNX Inference", getNextBoolean());
+
         return out;
     }
 
@@ -81,6 +83,7 @@ public class BatchView extends GenericDialog {
 
         addCheckbox("Save excel", true);
         addCheckbox("Save plot windows", false);
+        addCheckbox("ONNX Inference", false);
 
         showDialog();
 


### PR DESCRIPTION
Added ONNX model loading functionality.

ONNX model loading is separated from main plugin functionality as much as possible to prevent errors and undesired side effects.

# ONNX Inference Functionality
ONNX model loading functionality can be accessed via the following button, i.e. the panel is hidden by default.
![image](https://github.com/user-attachments/assets/bf48b405-7e73-4e3c-a9bb-28fe4b055170)

The ONNX inference panel is extremely basic, but it exposes the main necessary controls to execute ONNX inference on files.
![image](https://github.com/user-attachments/assets/34a59a5c-210a-4670-bf51-f7c66384f4ca)

# ONNX Model Loading
ONNX model loading requires ONNX files that can be produced via the `imfcs-pytorch` codebase, and has been tested to work with all model types. For simplicity, all data processing steps **except for bleach correction** are also baked into the PyTorch-to-ONNX casting process, so any transformations can be retained across different platforms, even Java if desired.

The current code will automatically populate the metadata fields based on the model training properties. This is done in the expectation that different model input shapes may be used in the future.

As models may have different number of outputs, the code is also designed in a way where an arbitrary number of output maps are supported.

# ONNX Inference
Inference can executed directly (i.e. the `Run Inference` button becomes enabled) once a model is loaded.

By default, the ONNX inference setup is designed to directly use a non-overlapping stride, but the user can choose to revert to "no overlap" mode (as termed by Wai Hoh in his paper) by setting the X- and Y-stride values to match the model input values.

### Strides of 1 - "Overlap"
![image](https://github.com/user-attachments/assets/e5704b77-55e8-4569-9f7b-3a752b53880b)

### Strides of 3 (Matching Model Properties) - "No Overlap"
![image](https://github.com/user-attachments/assets/8a01c25b-e211-4d40-8024-acffe5588ef3)

To produce videos with overlap, as previously done in the FCS Videos paper, the user can also set the Stride in the Frames dimension to arbitrary values to allow for overlapping inference over the time dimension.

# Inference Process
The ONNX inference functionality works in a 3-step process.

## Step 1:  Processing all pixels
This step runs bleach correction over each pixel as a "preparation" step. This creates a large float array to represent the currently loaded file.

This is necessary for the following reasons:
1. Unlike FCS fitting, most models need to consider multiple pixels in space for each input. This means conducting bleach correction for each pixel will result in repeated work. We can consider this preparation step to be an extreme form of memoization.
2. We can use this large array for lazy chunk generation. Since the model needs to fit inputs of a certain size, we use lazily extract chunks 1 at a time.

**NOTE: This process is the most memory intensive part, and when loading huge files (128x128x50000), Java's heap memory limit may be hit. This is because casting uint16 TIF files into floats immediately causes a size increase. **

## Step 2: Chunk Generation
Based on the model input sizes and the user-defined strides, we lazily generate chunks using the following procedure:
1. Compute the expected output shape, i.e. the shape of the prediction map.
2. Generate the start indices of each chunk that the ONNX model will process.
4. For each start index, create the corresponding output index, i.e. where the prediction for this chunk will belong in the output prediction map. These are returned as pairs, so the inference process can directly create the result object on-the-fly.
5. This `ChunkGenerator` can now be used to lazily extract 1 chunk at each time for processing. This ensures that memory does not blow up, especially with overlapping model input chunks.

**NOTE: For now, we use an extremely conservative batch size of 1 for ONNX inference. This ensures that memory use does not blow up, and is better for CPU inference. However, for GPU processing, this is extremely inefficient.**

# ONNX Session Management
While not necessary, we also include some functionality to manage the ONNX session.

Assumption: A user might be running an ImagingFCS plugin analysis session for quite some time, and ONNX inference might not be used for most of this process.

Solution: If the user closes the ONNX inference panel (by toggle), the ONNX inference session is torn down and deleted. The user's settings and loaded models are still present, but this frees up a significant amount of memory and is considered best practices.

If the user decides that they want to continue using the same ONNX inference session, they can re-init the session via the `Init Model` button (name is temporary).

![image](https://github.com/user-attachments/assets/c1194c84-eefe-41bf-b1c7-7c1bec30606a)

To direct the user down the desired flow, the `Run Inference` button is enabled and disabled dynamically depending on whether or not the ONNX Inference functionality is ready.

# Interfacing With Existing Components
The ONNX inference functionality only interfaces with the `ImageModel` and the bleach correction functionality, and some of the factory methods for constructing the user interface. 

An additional option was also included in `Batch` Processing mode to facilitate processing of existing data.
![image](https://github.com/user-attachments/assets/3ed621c0-6599-448b-a244-57bf16423b45)

This mode does not modify the existing Excel functionality (as all model predictions do not use the PixelModel representation of existing fitting procedures), and the Batch mode simply saves all outputs as TIF files, roughly recreating the functionality of the Python inference code with the `-output tif` flag.

![image](https://github.com/user-attachments/assets/8b094b3d-1f4a-4d6e-970e-2bf73b753f50)

# GPU Support
The ONNX Runtime we pull in from the Maven Repository is the CUDA-compatible version, so both CPU and CUDA support should be included. While CUDA seems to work when a CUDA-compatible GPU is available, the speedups are negligible due to the conservative data processing pipeline.

# TODOs
1. The model prediction values are never perfect matches to inference in PyTorch directly. This is not just due to the difference in bleach correction, but just a difference in numeric computation between ONNX and PyTorch. We try to mitigate this by turning off all runtime optimizations for ONNX, but the issue still remains.
2. UX is passable (to the PR submitter's opinion), but user studies are still needed to be sure if it works well.
3. Methods in each file are not well arranged.