### PR TITLE
Java21 compatibility and dll fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
                         <configuration>
                             <transformers>
                                 <transformer
-                                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>fiji.plugin.imaging_fcs.imfcs.ImagingFCS</mainClass>
                                 </transformer>
                             </transformers>
@@ -44,13 +44,52 @@
                 </configuration>
             </plugin>
         </plugins>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+            <resource>
+                <directory>${project.basedir}/src/main/cpp/build/gpufit/Release</directory>
+                <targetPath>libs/gpufit</targetPath>
+                <includes>
+                    <include>agpufit.dll</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>${project.basedir}/src/main/cpp/build/cameras/sdk2/Release</directory>
+                <targetPath>libs/camera_readout/sdk2</targetPath>
+                <includes>
+                    <include>JNIAndorSDK2v3.dll</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>${project.basedir}/src/main/cpp/build/cameras/sdk3/Release</directory>
+                <targetPath>libs/camera_readout/sdk3</targetPath>
+                <includes>
+                    <include>JNIAndorSDK3v2.dll</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>${project.basedir}/src/main/cpp/build/cameras/dcam/Release</directory>
+                <targetPath>libs/camera_readout/dcam</targetPath>
+                <includes>
+                    <include>JNIHamamatsuDCAMsdk4.dll</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>${project.basedir}/src/main/cpp/build/cameras/pvcam/Release</directory>
+                <targetPath>libs/camera_readout/pvcam</targetPath>
+                <includes>
+                    <include>JNIPhotometricsPVCAMsdk.dll</include>
+                </includes>
+            </resource>
+        </resources>
     </build>
 
     <properties>
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <!-- Skip tests if necessary, but consider enabling and writing tests for better software quality -->
         <maven.test.skip>true</maven.test.skip>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -214,7 +253,6 @@
 
         <profile>
             <id>compile_libs</id>
-            <!-- This profile activates when compile_libs is true -->
             <activation>
                 <property>
                     <name>compileLibs</name>
@@ -239,25 +277,11 @@
                                     <workingDirectory>${project.basedir}/src/main/cpp</workingDirectory>
                                     <arguments>
                                         <argument>-Bbuild</argument>
+                                        <argument>-G</argument>
+                                        <argument>Visual Studio 17 2022</argument>
+                                        <argument>-A</argument>
+                                        <argument>x64</argument>
                                         <argument>-DCMAKE_BUILD_TYPE=Release</argument>
-                                    </arguments>
-                                </configuration>
-                            </execution>
-
-                            <execution>
-                                <id>cmake-build</id>
-                                <phase>compile</phase>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <configuration>
-                                    <executable>cmake</executable>
-                                    <workingDirectory>${project.basedir}/src/main/cpp/build</workingDirectory>
-                                    <arguments>
-                                        <argument>--build</argument>
-                                        <argument>.</argument>
-                                        <argument>--config</argument>
-                                        <argument>Release</argument>
                                     </arguments>
                                 </configuration>
                             </execution>

--- a/src/main/java/fiji/plugin/imaging_fcs/directCameraReadout/andorsdk2v3/AndorSDK2v3.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/directCameraReadout/andorsdk2v3/AndorSDK2v3.java
@@ -954,7 +954,7 @@ public class AndorSDK2v3 {
     private static void writeLibraryFile(File Directory, String LibName, Boolean DeleteOnExit) {
         try {
             //NOTE: include package name, which becomes the folder name in .jar file.'
-            InputStream in = ClassLoader.class
+            InputStream in = AndorSDK2v3.class
                     .getResourceAsStream("/libs/camera_readout/sdk2/" + LibName);
             if (in == null) {
                 throw new FileNotFoundException("Library " + LibName + " is not available");

--- a/src/main/java/fiji/plugin/imaging_fcs/directCameraReadout/andorsdk3v2/AndorSDK3v2.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/directCameraReadout/andorsdk3v2/AndorSDK3v2.java
@@ -856,7 +856,7 @@ public class AndorSDK3v2 {
     private static void writeLibraryFile(File Directory, String LibName, Boolean DeleteOnExit) {
         try {
             //NOTE: include package name, which becomes the folder name in .jar file.'
-            InputStream in = ClassLoader.class.getResourceAsStream("/libs/camera_readout/sdk3/" + LibName);
+            InputStream in = AndorSDK3v2.class.getResourceAsStream("/libs/camera_readout/sdk3/" + LibName);
             if (in == null) {
                 throw new FileNotFoundException("Library " + LibName + " is not available");
             }

--- a/src/main/java/fiji/plugin/imaging_fcs/directCameraReadout/hamadcamsdk4/Hamamatsu_DCAM_SDK4.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/directCameraReadout/hamadcamsdk4/Hamamatsu_DCAM_SDK4.java
@@ -729,7 +729,7 @@ public class Hamamatsu_DCAM_SDK4 {
     private static void writeLibraryFile(File Directory, String LibName, Boolean DeleteOnExit) {
         try {
             //NOTE: include package name, which becomes the folder name in .jar file.'
-            InputStream in = ClassLoader.class.getResourceAsStream("/libs/camera_readout/dcam/" + LibName);
+            InputStream in = Hamamatsu_DCAM_SDK4.class.getResourceAsStream("/libs/camera_readout/dcam/" + LibName);
             if (in == null) {
                 throw new FileNotFoundException("Library " + LibName + " is not available");
             }

--- a/src/main/java/fiji/plugin/imaging_fcs/directCameraReadout/pvcamsdk/Photometrics_PVCAM_SDK.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/directCameraReadout/pvcamsdk/Photometrics_PVCAM_SDK.java
@@ -713,7 +713,7 @@ public class Photometrics_PVCAM_SDK {
     private static void writeLibraryFile(File Directory, String LibName, Boolean DeleteOnExit) {
         try {
             //NOTE: include package name, which becomes the folder name in .jar file.'
-            InputStream in = ClassLoader.class.getResourceAsStream("/libs/camera_readout/pvcam/" + LibName);
+            InputStream in = Photometrics_PVCAM_SDK.class.getResourceAsStream("/libs/camera_readout/pvcam/" + LibName);
             if (in == null) {
                 throw new FileNotFoundException("Library " + LibName + " is not available");
             }

--- a/src/main/java/fiji/plugin/imaging_fcs/version/VERSION.java
+++ b/src/main/java/fiji/plugin/imaging_fcs/version/VERSION.java
@@ -2,7 +2,7 @@ package fiji.plugin.imaging_fcs.version;
 
 public class VERSION {
 
-    public static final String IMFCS_VERSION = "v.2_0_3";               // increment for any changes in
+    public static final String IMFCS_VERSION = "v.2_0_4";               // increment for any changes in
     // post-processing software
     public static final String GPUFIT_VERSION = "v1_1_2";           // increment for any changes in gpufit
     public static final String DCR_VERSION = "v1.29";            // increment for any changes in live readout feature


### PR DESCRIPTION
Code changes for the v2.0.4 release, backported after critical bugfixes.

# Summary of Changes
- Fixed broken DLL loading bugs in the most recent v2.0.3 release.
- Fixed Java 21-specific issues due to [Fiji now being Java 21 by default](https://forum.image.sc/t/fiji-latest-java-21-bundles-ready-for-community-testing/112417). Code is tested to work on both `fiji-latest` (Java 21) and `fiji-stable`(Java 8)
- Fixed README.md to include actual working compilation steps, and steps that better reflect the required manual intervention.

# Regressions
- Not in code, only in Fiji release of v2.0.4: Due to the inability to compile a Linux `libagpufit.so` manually, **we formally remove support for End-of-Life Linux distributions like CentOS 7 and Ubuntu 18.04**. Fiji release v2.0.4 was tested to work on Ubuntu 24.04 LTS with GPU fitting support.